### PR TITLE
Add AGENTS.md with Cursor Cloud environment notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository (`vibe-to-ui`) is a **content-only Agent Skill package**, not a runnable
+application. It contains only Markdown: `SKILL.md` (core instructions with YAML
+frontmatter), `references/*.md` (on-demand methodology guides), and
+`assets/design-system-template.md` (an output template). See `README.md` for the product
+overview and the `npx skills add ...` consumer install path.
+
+Because of this, there is **no application server, no build step, no automated test
+suite, and no linter** configured, and there are **no package manifests or lockfiles** to
+install from. The startup update script is intentionally a no-op.
+
+### Validating changes (the closest analog to test/lint here)
+
+The meaningful integrity checks for this repo are:
+
+1. `SKILL.md` has valid YAML frontmatter with required `name` (lowercase/digits/hyphens)
+   and `description` fields, per the [Agent Skills spec](https://agentskills.io/specification).
+2. Every internal Markdown link (e.g. `references/DESIGN-SYSTEM.md`) resolves to a real
+   file. Broken cross-references are the most likely regression when editing content.
+
+### Consuming / demonstrating the skill
+
+The official consumer tooling is the `skills` CLI (already runnable via `npx skills ...`).
+To verify the package installs and is recognized end-to-end from a local checkout:
+
+```bash
+# from any scratch project dir
+npx --yes skills add /workspace --skill '*' --agent '*' -y
+npx --yes skills list   # should list "vibe-to-ui"
+```
+
+This copies the skill into `./.agents/skills/vibe-to-ui` and is the real-world way an
+agent loads it. No network/auth is required when installing from the local path.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This repository is a **content-only Agent Skill package** (`vibe-to-ui`) — only Markdown, with no application, package manifests, build, tests, lint, or services. There is nothing to install, so the cloud startup update script is a no-op (`true`).

This PR adds `AGENTS.md` documenting that fact for future cloud agents, along with the two meaningful integrity checks (YAML frontmatter validity + internal-link resolution) and the official `skills` CLI consumption flow.

## Environment verification

No code changes to the skill content were made. I verified the environment by validating the skill package and consuming it via the official tooling:

- ✅ `python3 validate_skill.py` — parsed `SKILL.md` frontmatter; validated required `name`/`description`; checked 15 internal links across 12 Markdown files (all resolve).
- ✅ `npx --yes skills add /workspace --skill '*' --agent '*' -y` — installed the skill into `./.agents/skills/vibe-to-ui` for all detected agents.
- ✅ `npx --yes skills list` — skill `vibe-to-ui` listed and recognized for Cursor.

Logs:
[skill_validation.log](https://cursor.com/agents/bc-ab06a7fe-7a9a-410f-85aa-d1ba63708961/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fskill_validation.log)
[skill_install.log](https://cursor.com/agents/bc-ab06a7fe-7a9a-410f-85aa-d1ba63708961/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fskill_install.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab06a7fe-7a9a-410f-85aa-d1ba63708961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab06a7fe-7a9a-410f-85aa-d1ba63708961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

