### PR TITLE
Add progressive-load Motion Engine Router (Motion / GSAP / OGL / R3F)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Expose MCP tools such as `generate_image(prompt, width, height, reference_path?)
 │   ├── DESIGN-EXPLORATION.md         # Interactive exploration conversation guide
 │   ├── SPATIAL-VIBE.md               # Feeling-driven layout exploration guide
 │   ├── MOTION-SYSTEM.md              # Motion system extraction and generation guide
+│   ├── MOTION-ENGINE-ROUTER.md       # Progressive-load engine selection (Motion / GSAP / OGL / R3F)
 │   ├── AESTHETIC-ANALYSIS.md         # Aesthetic soul capture methodology
 │   ├── CONTEXT-COLLABORATION.md      # DESIGN.md collaboration protocol
 │   ├── ICON-USAGE.md                 # Icon component guidelines

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Expose MCP tools such as `generate_image(prompt, width, height, reference_path?)
 │   ├── DESIGN-EXPLORATION.md         # Interactive exploration conversation guide
 │   ├── SPATIAL-VIBE.md               # Feeling-driven layout exploration guide
 │   ├── MOTION-SYSTEM.md              # Motion system extraction and generation guide
-│   ├── MOTION-ENGINE-ROUTER.md       # Progressive-load engine selection (Motion / GSAP / OGL / R3F)
+│   ├── MOTION-ENGINE-ROUTER.md       # Progressive-load engine router (web/React/Vue × L1–L4)
 │   ├── AESTHETIC-ANALYSIS.md         # Aesthetic soul capture methodology
 │   ├── CONTEXT-COLLABORATION.md      # DESIGN.md collaboration protocol
 │   ├── ICON-USAGE.md                 # Icon component guidelines

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -254,6 +254,7 @@ vibe-to-ui **仅包含指令文档**，不内置 API Key，也不直接调用图
 │   ├── DESIGN-EXPLORATION.md         # 交互式探索对话指南
 │   ├── SPATIAL-VIBE.md               # 感受驱动的布局探索指南
 │   ├── MOTION-SYSTEM.md              # 动效系统提取与生成指南
+│   ├── MOTION-ENGINE-ROUTER.md       # 渐进加载动效引擎路由（Motion / GSAP / OGL / R3F）
 │   ├── AESTHETIC-ANALYSIS.md         # 美学灵魂捕获方法论
 │   ├── CONTEXT-COLLABORATION.md      # DESIGN.md 协作协议
 │   ├── ICON-USAGE.md                 # 图标组件指南

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -254,7 +254,7 @@ vibe-to-ui **仅包含指令文档**，不内置 API Key，也不直接调用图
 │   ├── DESIGN-EXPLORATION.md         # 交互式探索对话指南
 │   ├── SPATIAL-VIBE.md               # 感受驱动的布局探索指南
 │   ├── MOTION-SYSTEM.md              # 动效系统提取与生成指南
-│   ├── MOTION-ENGINE-ROUTER.md       # 渐进加载动效引擎路由（Motion / GSAP / OGL / R3F）
+│   ├── MOTION-ENGINE-ROUTER.md       # 渐进加载动效引擎路由（Web/React/Vue × L1–L4）
 │   ├── AESTHETIC-ANALYSIS.md         # 美学灵魂捕获方法论
 │   ├── CONTEXT-COLLABORATION.md      # DESIGN.md 协作协议
 │   ├── ICON-USAGE.md                 # 图标组件指南

--- a/SKILL.md
+++ b/SKILL.md
@@ -147,20 +147,20 @@ User provides a complete UI screenshot or design mockup -> Extract the design sy
    - typography hierarchy and readability needs
    - color semantics, especially status and priority colors for B-end surfaces
    - component patterns that fit the classified archetype
-4. Analyze the motion system with the page type in mind:
+4. Analyze the motion system with the page type in mind (Motion DNA only — **do not** load the Motion Engine Router yet):
    - landing pages can support more entrance choreography
    - dashboards prefer subtle transitions and focus-preserving movement
    - dense workbenches should avoid decorative motion that interrupts scanning
    - consumer apps need fast, tactile feedback, clear screen transitions, and complete reduced-motion fallbacks
-   - when **implementing** motion in preview or project code, progressively load [references/MOTION-ENGINE-ROUTER.md](references/MOTION-ENGINE-ROUTER.md): compile Motion DNA → detect stack family (`web` / `react` / `vue`) → select exactly one engine tier (L1 / GSAP / OGL / Three.js family) with the correct stack binding → one primary recipe → dependency, mobile, and reduced-motion fallbacks
+   - extract tempo, easing, density, distance, personality, and one **signature motion motif** from the reference/vibe (see [references/MOTION-SYSTEM.md](references/MOTION-SYSTEM.md))
 5. Output a structured design system including:
    - page type summary
    - design constraints derived from the page archetype
    - visual tokens
-   - motion tokens
+   - motion tokens + signature motion motif
    - consumer app system fields from [references/CONSUMER-APP-DESIGN.md](references/CONSUMER-APP-DESIGN.md) when applicable
 6. If the user wants a richer aesthetic guide (soul-level, not just tokens), also generate an Aesthetic Analysis document following [references/AESTHETIC-ANALYSIS.md](references/AESTHETIC-ANALYSIS.md), but keep it subordinate to the page type constraints
-7. **Generate a standalone preview page** as an HTML artifact showcasing the extracted design system applied to sample components. This is NOT applied to the project yet.
+7. **Generate a standalone preview page** as an HTML artifact showcasing the extracted design system applied to sample components. This is NOT applied to the project yet. **When writing the preview's motion code**, progressively load [references/MOTION-ENGINE-ROUTER.md](references/MOTION-ENGINE-ROUTER.md): compile Motion DNA → detect stack family (`web` / `react` / `vue`) → select one engine tier + stack binding → one primary recipe (mutate parameters from DNA/signature motif — do not ship recipe defaults unchanged) → dependency, mobile, and reduced-motion fallbacks.
 8. Ask the user to confirm or adjust both the **page type classification** and the extracted values
 9. Once the user confirms, transition to **Capability 5** (Apply Design to Project) to integrate the design system into the actual project
 
@@ -199,7 +199,7 @@ User has feelings or vibes but no concrete design target -> Interactive conversa
 8. Synthesize findings into **3 distinct design concept directions**, each with:
    - clear inheritance from the reference or product context
    - a distinct typography direction, not just a color change
-   - a motion personality
+   - a motion personality **and one signature motion motif** (what makes this direction's movement memorable)
    - a density posture
    - a clear statement of why it fits the page type
    - for Consumer app surfaces, a distinct app experience posture: navigation model, primary loop, key state strategy, and tactile interaction feel
@@ -207,13 +207,24 @@ User has feelings or vibes but no concrete design target -> Interactive conversa
 10. For each concept, generate a **standalone concept preview page** as a self-contained HTML artifact:
    - a styled sample card or module from the actual page archetype
    - the concept name, color swatches, typography rationale, font samples, and a mini layout demo
-   - motion preview with hover states and entrance effects appropriate to the page type
+   - motion preview using **Exploration Interim Motion** rules below (do **not** load the full Motion Engine Router yet unless the user asks to formalize implementation)
    - explicit comparison between heading, body, label, and dense-data text where relevant
    - for Consumer app surfaces, show realistic app modules from [references/CONSUMER-APP-DESIGN.md](references/CONSUMER-APP-DESIGN.md): navigation, core screen, detail/create flow, non-happy state, and tap/sheet/tab motion
    - these are standalone pages for exploration and do NOT modify the user's project
 11. Let the user react, compare, and choose or mix elements
 12. Once the user decides, apply **Capability 1** (Design System Extraction) to formalize the chosen direction into a complete design system including motion tokens
-13. Transition to **Capability 5** (Apply Design to Project) to integrate the confirmed design into the actual project
+13. Transition to **Capability 5** (Apply Design to Project) to integrate the confirmed design into the actual project. **On Apply**, load [references/MOTION-ENGINE-ROUTER.md](references/MOTION-ENGINE-ROUTER.md) for production motion code.
+
+#### Exploration Interim Motion (before Router load)
+
+During Capability 2 concept previews and mood boards, motion must still feel intentional — but stay lightweight:
+
+1. Draft a **provisional Motion DNA** per concept: tempo, easing, density, distance, personality, signature motif
+2. Implement with **CSS custom properties + CSS transitions/keyframes only** in the standalone HTML (no GSAP/OGL/Three CDN demos)
+3. Show **one** signature motif + essential feedback (hover/tap); for Consumer apps also show sheet rise and tab indicator using CSS
+4. Vary the signature motif across the 3 concepts so comparison is about *feeling*, not only color
+5. Forbidden in exploration: library default demos, fade-up-everything, bounce-everywhere, particle fields, purple glow loops
+6. When the user confirms a direction and you need production-grade motion code, **then** load the Motion Engine Router
 
 ### 3. Spatial Vibe Exploration
 
@@ -394,5 +405,6 @@ Spatial Vibe outputs should include:
 - For typography, note both the font family and the scale ratios, not just absolute sizes
 - Spacing should be expressed as a consistent scale (for example a 4px base unit)
 - Motion tokens should always include `prefers-reduced-motion` fallbacks. Accessibility is non-negotiable.
-- When writing motion **implementation** code (not during exploration), load [references/MOTION-ENGINE-ROUTER.md](references/MOTION-ENGINE-ROUTER.md). Detect whether the surface is **web**, **React**, or **Vue**, then use the simplest engine tier that can express the confirmed Motion DNA with that stack's binding (e.g. `motion` / `motion-v` / GSAP / OGL / R3F / TresJS). Never mix engines, cross-wire React packages into Vue (or vice versa), stack decorative effects, or copy library default demo styles on the same surface.
+- During **exploration**, use Exploration Interim Motion (CSS + provisional DNA + signature motif). Do **not** load the Motion Engine Router for mood boards or early concept feeling checks.
+- When writing motion **implementation** code (design-system preview Step 7, confirmed concept productionization, or Capability 5 Apply), load [references/MOTION-ENGINE-ROUTER.md](references/MOTION-ENGINE-ROUTER.md). Detect whether the surface is **web**, **React**, or **Vue**, then use the simplest engine tier with the correct stack binding. Mutate recipe parameters from Motion DNA and the signature motif — never ship unchanged library defaults. Never mix engines, cross-wire React packages into Vue (or vice versa), stack decorative effects, or copy demo aesthetics.
 - Be honest when visual analysis is uncertain. Flag low-confidence extractions and suggest the user verify.

--- a/SKILL.md
+++ b/SKILL.md
@@ -152,6 +152,7 @@ User provides a complete UI screenshot or design mockup -> Extract the design sy
    - dashboards prefer subtle transitions and focus-preserving movement
    - dense workbenches should avoid decorative motion that interrupts scanning
    - consumer apps need fast, tactile feedback, clear screen transitions, and complete reduced-motion fallbacks
+   - when **implementing** motion in preview or project code, progressively load [references/MOTION-ENGINE-ROUTER.md](references/MOTION-ENGINE-ROUTER.md): compile Motion DNA → select exactly one engine (Motion / GSAP / OGL / Three.js-R3F) → one primary recipe → dependency, mobile, and reduced-motion fallbacks
 5. Output a structured design system including:
    - page type summary
    - design constraints derived from the page archetype
@@ -393,4 +394,5 @@ Spatial Vibe outputs should include:
 - For typography, note both the font family and the scale ratios, not just absolute sizes
 - Spacing should be expressed as a consistent scale (for example a 4px base unit)
 - Motion tokens should always include `prefers-reduced-motion` fallbacks. Accessibility is non-negotiable.
+- When writing motion **implementation** code (not during exploration), load [references/MOTION-ENGINE-ROUTER.md](references/MOTION-ENGINE-ROUTER.md). Use the simplest engine tier that can express the confirmed Motion DNA; never mix engines, stack decorative effects, or copy library default demo styles on the same surface.
 - Be honest when visual analysis is uncertain. Flag low-confidence extractions and suggest the user verify.

--- a/SKILL.md
+++ b/SKILL.md
@@ -152,7 +152,7 @@ User provides a complete UI screenshot or design mockup -> Extract the design sy
    - dashboards prefer subtle transitions and focus-preserving movement
    - dense workbenches should avoid decorative motion that interrupts scanning
    - consumer apps need fast, tactile feedback, clear screen transitions, and complete reduced-motion fallbacks
-   - when **implementing** motion in preview or project code, progressively load [references/MOTION-ENGINE-ROUTER.md](references/MOTION-ENGINE-ROUTER.md): compile Motion DNA → select exactly one engine (Motion / GSAP / OGL / Three.js-R3F) → one primary recipe → dependency, mobile, and reduced-motion fallbacks
+   - when **implementing** motion in preview or project code, progressively load [references/MOTION-ENGINE-ROUTER.md](references/MOTION-ENGINE-ROUTER.md): compile Motion DNA → detect stack family (`web` / `react` / `vue`) → select exactly one engine tier (L1 / GSAP / OGL / Three.js family) with the correct stack binding → one primary recipe → dependency, mobile, and reduced-motion fallbacks
 5. Output a structured design system including:
    - page type summary
    - design constraints derived from the page archetype
@@ -394,5 +394,5 @@ Spatial Vibe outputs should include:
 - For typography, note both the font family and the scale ratios, not just absolute sizes
 - Spacing should be expressed as a consistent scale (for example a 4px base unit)
 - Motion tokens should always include `prefers-reduced-motion` fallbacks. Accessibility is non-negotiable.
-- When writing motion **implementation** code (not during exploration), load [references/MOTION-ENGINE-ROUTER.md](references/MOTION-ENGINE-ROUTER.md). Use the simplest engine tier that can express the confirmed Motion DNA; never mix engines, stack decorative effects, or copy library default demo styles on the same surface.
+- When writing motion **implementation** code (not during exploration), load [references/MOTION-ENGINE-ROUTER.md](references/MOTION-ENGINE-ROUTER.md). Detect whether the surface is **web**, **React**, or **Vue**, then use the simplest engine tier that can express the confirmed Motion DNA with that stack's binding (e.g. `motion` / `motion-v` / GSAP / OGL / R3F / TresJS). Never mix engines, cross-wire React packages into Vue (or vice versa), stack decorative effects, or copy library default demo styles on the same surface.
 - Be honest when visual analysis is uncertain. Flag low-confidence extractions and suggest the user verify.

--- a/assets/design-system-template.md
+++ b/assets/design-system-template.md
@@ -326,6 +326,19 @@ If the confirmed direction includes an ASCII architecture sketch, visual thumbna
 - Disable parallax and scroll-linked decorative effects
 - Keep meaning-bearing motion only in simplified form
 
+### Motion Engine (implementation only)
+
+Fill this section when implementing motion in preview or project code — not during exploration. See [../references/MOTION-ENGINE-ROUTER.md](../references/MOTION-ENGINE-ROUTER.md).
+
+- **Selected tier**: [L1 Motion / L2 GSAP / L3 OGL / L4 Three.js-R3F]
+- **Primary recipe**: [recipe id from router, e.g. `in-view-stagger`]
+- **Secondary recipe**: [optional, or none]
+- **Escalation reason**: [why a higher tier was required, or N/A]
+- **Rejected tiers**: [e.g. L3, L4 — with one-line reason each]
+- **Dependency check**: [pass / fail notes]
+- **Mobile strategy**: [e.g. static poster, reduced distance, no scroll-scrub]
+- **Decorative budget**: [none / one atmosphere effect — name it]
+
 ## Preview Artifact
 
 - **Artifact type**: standalone HTML preview page

--- a/assets/design-system-template.md
+++ b/assets/design-system-template.md
@@ -330,7 +330,9 @@ If the confirmed direction includes an ASCII architecture sketch, visual thumbna
 
 Fill this section when implementing motion in preview or project code — not during exploration. See [../references/MOTION-ENGINE-ROUTER.md](../references/MOTION-ENGINE-ROUTER.md).
 
-- **Selected tier**: [L1 Motion / L2 GSAP / L3 OGL / L4 Three.js-R3F]
+- **Stack family**: [web / react / vue]
+- **Stack binding**: [e.g. css-tokens / motion / framer-motion / motion-v / @vueuse/motion / gsap / ogl / three / r3f / tresjs]
+- **Selected tier**: [L1 / L2 GSAP / L3 OGL / L4 Three.js family]
 - **Primary recipe**: [recipe id from router, e.g. `in-view-stagger`]
 - **Secondary recipe**: [optional, or none]
 - **Escalation reason**: [why a higher tier was required, or N/A]

--- a/assets/design-system-template.md
+++ b/assets/design-system-template.md
@@ -300,6 +300,7 @@ If the confirmed direction includes an ASCII architecture sketch, visual thumbna
 - **Density**: [minimal / moderate / rich]
 - **Distance**: [small / medium / large] — base translate: [for example `12px`]
 - **Personality**: [reliable and composed / innovative and performant / guiding and supportive / premium and luxurious / playful and energetic]
+- **Signature motif**: [one memorable motion sentence derived from vibe/reference — e.g. "soft paper settle: 12px rise, calm ease-out, 60ms stagger"]
 - **Reduced motion**: [fade only / static / simplified / pausable]
 
 ### Motion Tokens
@@ -333,13 +334,16 @@ Fill this section when implementing motion in preview or project code — not du
 - **Stack family**: [web / react / vue]
 - **Stack binding**: [e.g. css-tokens / motion / framer-motion / motion-v / @vueuse/motion / gsap / ogl / three / r3f / tresjs]
 - **Selected tier**: [L1 / L2 GSAP / L3 OGL / L4 Three.js family]
-- **Primary recipe**: [recipe id from router, e.g. `in-view-stagger`]
-- **Secondary recipe**: [optional, or none]
+- **Primary recipe**: [recipe id from router, e.g. `in-view-stagger` / `sheet-rise` / `tab-indicator`]
+- **Secondary recipe**: [optional feedback+guidance pair only, or none]
+- **Recipe mutations**: [how DNA/signature motif changed defaults]
+- **Signature motif**: [same as Motion Character, carried into implementation]
 - **Escalation reason**: [why a higher tier was required, or N/A]
 - **Rejected tiers**: [e.g. L3, L4 — with one-line reason each]
 - **Dependency check**: [pass / fail notes]
 - **Mobile strategy**: [e.g. static poster, reduced distance, no scroll-scrub]
 - **Decorative budget**: [none / one atmosphere effect — name it]
+- **Mediocrity self-review**: [pass / fail — motif, lineage, mutation, budget, a11y]
 
 ## Preview Artifact
 

--- a/references/DESIGN-SYSTEM.md
+++ b/references/DESIGN-SYSTEM.md
@@ -292,7 +292,7 @@ Then explain motion through the page-type lens:
 
 For deeper extraction guidance, read [MOTION-SYSTEM.md](MOTION-SYSTEM.md).
 
-When generating preview or project motion **code**, progressively load [MOTION-ENGINE-ROUTER.md](MOTION-ENGINE-ROUTER.md) after Motion DNA is locked. Select one engine tier, one primary recipe, run dependency checks, and document `motion_engine_decision` before implementation.
+When generating preview or project motion **code**, progressively load [MOTION-ENGINE-ROUTER.md](MOTION-ENGINE-ROUTER.md) after Motion DNA is locked. Detect stack family (`web` / `react` / `vue`), select one engine tier with the matching package binding, pick one primary recipe, run dependency checks, and document `motion_engine_decision` before implementation.
 
 ---
 

--- a/references/DESIGN-SYSTEM.md
+++ b/references/DESIGN-SYSTEM.md
@@ -292,7 +292,7 @@ Then explain motion through the page-type lens:
 
 For deeper extraction guidance, read [MOTION-SYSTEM.md](MOTION-SYSTEM.md).
 
-When generating preview or project motion **code**, progressively load [MOTION-ENGINE-ROUTER.md](MOTION-ENGINE-ROUTER.md) after Motion DNA is locked. Detect stack family (`web` / `react` / `vue`), select one engine tier with the matching package binding, pick one primary recipe, run dependency checks, and document `motion_engine_decision` before implementation.
+When generating preview or project motion **code**, progressively load [MOTION-ENGINE-ROUTER.md](MOTION-ENGINE-ROUTER.md) after Motion DNA and signature motif are locked. Detect stack family (`web` / `react` / `vue`), select one engine tier with the matching package binding, pick one primary recipe, **mutate** it from the signature motif, run dependency checks, and document `motion_engine_decision` before implementation. Exploration concept previews use CSS interim motion instead of this router.
 
 ---
 

--- a/references/DESIGN-SYSTEM.md
+++ b/references/DESIGN-SYSTEM.md
@@ -292,6 +292,8 @@ Then explain motion through the page-type lens:
 
 For deeper extraction guidance, read [MOTION-SYSTEM.md](MOTION-SYSTEM.md).
 
+When generating preview or project motion **code**, progressively load [MOTION-ENGINE-ROUTER.md](MOTION-ENGINE-ROUTER.md) after Motion DNA is locked. Select one engine tier, one primary recipe, run dependency checks, and document `motion_engine_decision` before implementation.
+
 ---
 
 ## 7. Component and Module Patterns

--- a/references/MOTION-ENGINE-ROUTER.md
+++ b/references/MOTION-ENGINE-ROUTER.md
@@ -4,12 +4,25 @@ Progressive-load reference. **Do not read this file during vibe exploration, moo
 
 ## Purpose
 
-Turn the user's vibe and confirmed Motion DNA into **one** implementation engine and **one** minimal recipe set. The router exists so agents:
+Turn the user's vibe and confirmed Motion DNA into **one** implementation engine, **one** stack binding, and **one** minimal recipe set. The router exists so agents:
 
 1. Express the target feeling with the **simplest technology that can carry it**
-2. **Never mix engines** on the same surface
-3. **Never stack** decorative effects (parallax + particles + 3D + scroll scrub on the same hero)
-4. **Never copy** library default demo aesthetics (generic floating shapes, stock purple gradients, boilerplate particle fields)
+2. Bind that engine to the project's **Web / React / Vue** stack family — not a kitchen-sink multi-platform catalog
+3. **Never mix engines** on the same surface
+4. **Never stack** decorative effects (parallax + particles + 3D + scroll scrub on the same hero)
+5. **Never copy** library default demo aesthetics (generic floating shapes, stock purple gradients, boilerplate particle fields)
+
+## Product scope (what this router covers)
+
+vibe-to-ui is a **web-first design companion**. Motion implementation guidance covers three stack families only:
+
+| Family | Detect when | Out of scope |
+|--------|-------------|--------------|
+| **Web** | Vanilla HTML/CSS, static preview HTML, Astro content islands without a SPA framework, Tailwind-only pages | — |
+| **React** | `react`, Next.js, Remix, Vite+React, shadcn/ui (React) | React Native |
+| **Vue** | `vue`, Nuxt, Vite+Vue, Nuxt UI | Native mobile |
+
+**Do not** invent Flutter / RN / SwiftUI / Compose motion paths here. If the project is native-mobile, keep Motion DNA as tokens and ask the user which web surface (if any) should receive implementation.
 
 ## Router pipeline
 
@@ -20,9 +33,11 @@ Motion DNA (8 dimensions + narrative from MOTION-SYSTEM.md)
         ↓
 Capability check (what must be expressed?)
         ↓
+Stack family detect (web | react | vue)
+        ↓
 Dependency audit (project + device + a11y)
         ↓
-Engine selection (exactly one: L1–L4)
+Engine selection (exactly one: L1–L4) + stack binding
         ↓
 Recipe pick (1 primary + at most 1 supporting pattern)
         ↓
@@ -34,9 +49,10 @@ Implement with tokens + fallbacks
 | Rule | Requirement |
 |------|-------------|
 | **One engine per surface** | A page, screen, or preview artifact uses **one** engine tier. Shared layout CSS transitions are allowed; do not add a second animation runtime. |
-| **Simplest sufficient layer** | Start at L1 (Motion). Escalate only when L1 cannot express a **required** capability (see ladder below). |
+| **Simplest sufficient layer** | Start at L1. Escalate only when L1 cannot express a **required** capability (see ladder below). |
+| **Stack follows the project** | Prefer packages already in `package.json`. Do not force React Motion into a Vue app or TresJS into a React app. |
 | **One decorative motion budget** | At most **one** atmosphere-class effect per surface (role = atmosphere in Motion DNA). Feedback and guidance patterns are separate and stay minimal. |
-| **No demo cosplay** | Do not reproduce official examples (Framer Motion layout demos, GSAP ScrollSmoother defaults, Three.js particle fields, shader toy noise). Derive motion from **Motion DNA + design tokens**. |
+| **No demo cosplay** | Do not reproduce official examples (Motion layout demos, GSAP ScrollSmoother defaults, Three.js particle fields, Tres/drei boilerplate). Derive motion from **Motion DNA + design tokens**. |
 | **Page type wins** | B-end / dense surfaces default to L1 or CSS-only. Landing / brand may reach L2–L4 only when atmosphere is an explicit design goal. |
 | **Reduced motion first-class** | Every recipe ships with a `prefers-reduced-motion` branch before shipping. |
 | **Mobile honesty** | If the chosen recipe cannot hold 60fps on mid-tier mobile, downgrade engine tier or switch to static / simplified fallback — do not ship jank. |
@@ -78,42 +94,74 @@ Ask: **What is the minimum expressiveness required?**
 
 | Required capability | Minimum tier |
 |--------------------|--------------|
-| Hover / tap feedback, enter/exit, layout morph, modal, tab, list stagger | **L1 Motion** |
+| Hover / tap feedback, enter/exit, layout morph, modal, tab, list stagger | **L1** |
 | Scroll-scrubbed narrative, pinned sections, complex multi-step timeline, horizontal scroll choreography | **L2 GSAP** |
 | Full-screen shader atmosphere, 2D WebGL image warp, lightweight GPU gradient/noise tied to scroll or pointer | **L3 OGL** |
-| True 3D object, camera path, lighting on mesh, interactive orbit, spatial product hero | **L4 Three.js / R3F** |
+| True 3D object, camera path, lighting on mesh, interactive orbit, spatial product hero | **L4 Three.js family** |
 
 If multiple rows match, pick the **lowest** tier that covers all **functional** requirements. Atmosphere alone never justifies L4.
 
-## Step 3 — Engine ladder
+## Step 3 — Stack family adapter
 
-| Tier | Engine | Runtime | Typical stack |
-|------|--------|---------|---------------|
-| **L1** | **Motion** (`motion` / `framer-motion`) | React declarative | Next.js, Vite + React |
-| **L2** | **GSAP** (+ ScrollTrigger when needed) | Imperative timeline | Any DOM; React use `useGSAP` / `gsap.context` |
-| **L3** | **OGL** | Minimal WebGL | Vanilla or React wrapper; no full scene graph |
-| **L4** | **Three.js** / **React Three Fiber** | Full 3D | `@react-three/fiber` + `@react-three/drei` when in React |
+Detect the project's stack family **before** locking packages. Capability chooses the **tier**; stack family chooses the **binding**.
+
+### Detection signals
+
+| Family | Signals (any strong match) |
+|--------|----------------------------|
+| **react** | `react` / `next` / `react-dom` in deps; `.tsx` app router; shadcn/ui; Remix |
+| **vue** | `vue` / `nuxt` / `nuxt-ui` in deps; `.vue` SFCs; Vite Vue plugin |
+| **web** | No SPA framework; static HTML preview; Astro content-only; plain Tailwind/CSS |
+
+If both React and Vue appear (e.g. Astro islands), bind to the **island framework that owns the animated surface**, not the site shell.
+
+If detection confidence is low, ask one short question: "Is this surface React, Vue, or plain HTML?"
+
+### Tier → package binding matrix
+
+| Tier | Capability | **Web** binding | **React** binding | **Vue** binding |
+|------|------------|-----------------|-------------------|-----------------|
+| **L1** | Declarative UI motion | CSS transitions/animations first; escalate to vanilla **`motion`** (`animate` / `scroll`) only if CSS cannot express stagger/gestures | **`motion`** (preferred) or `framer-motion` if already installed | **`motion-v`** (preferred Motion-for-Vue); if project already uses **`@vueuse/motion`**, keep it — do not dual-install |
+| **L2** | Timeline / scroll choreography | **`gsap`** + `ScrollTrigger` | **`gsap`** + `@gsap/react` (`useGSAP`) / `gsap.context` | **`gsap`** + `ScrollTrigger`; cleanup in `onUnmounted` via `gsap.context` / `ctx.revert()` |
+| **L3** | Lightweight WebGL / shader plane | **`ogl`** (vanilla canvas) | **`ogl`** in a client component (or thin wrapper); avoid a second 3D framework | **`ogl`** in `onMounted` / `onBeforeUnmount`; dispose on unmount |
+| **L4** | True 3D scene | **`three`** (vanilla) | **`three`** + **`@react-three/fiber`**; `@react-three/drei` only when justified | **`three`** + **`@tresjs/core`** (TresJS); `@tresjs/cientos` only when justified; Nuxt may use `@tresjs/nuxt` |
+
+### Stack adapter rules
+
+1. **Same tier, different package** — L1 on Vue is `motion-v`, not React `motion`. Do not cross-wire.
+2. **Prefer already-installed peers** — If `framer-motion` is present and `motion` is not, stay on `framer-motion`. If `@vueuse/motion` is present and DNA fits, stay — do not add `motion-v` just for brand alignment.
+3. **Web L1 stays CSS-first** — Standalone HTML previews should prefer CSS `@keyframes` / transitions bound to design tokens. Add vanilla `motion` only when gestures, layout handoff, or orchestrated stagger are required.
+4. **Astro / multi-island** — Animate inside one island with one engine; do not put GSAP in the layout and Motion inside a React island on the same hero.
+5. **Out of scope stacks** — RN, Flutter, SwiftUI, Compose: emit Motion DNA only; do not fake a web binding.
+
+## Step 4 — Engine ladder
+
+| Tier | Engine (capability name) | Runtime idea |
+|------|--------------------------|--------------|
+| **L1** | Declarative motion (Motion family / CSS) | Component or CSS-driven UI motion |
+| **L2** | **GSAP** (+ ScrollTrigger when needed) | Imperative timeline / scrub |
+| **L3** | **OGL** | Minimal WebGL quad / shader |
+| **L4** | **Three.js family** (vanilla / R3F / TresJS) | Full 3D scene |
 
 Escalation requires a **written reason** tied to Motion DNA, not "it would look cool."
 
-## Step 4 — Selection & rejection matrix
+## Step 5 — Selection & rejection matrix
 
-### L1 — Motion
+### L1 — Declarative motion
 
 **Choose when**
 
-- React (or preview HTML with React CDN) is the implementation surface
 - Motion roles are feedback, guidance, explanation with DOM/CSS-friendly transforms
 - Density is minimal or moderate
 - Consumer app tactile patterns (press, sheet, tab indicator)
 - Page metaphor is product manual, dashboard, or form
+- Stack is Web (CSS/`motion`), React (`motion`), or Vue (`motion-v` / `@vueuse/motion`)
 
 **Reject when**
 
 - Scroll position must drive animation progress with sub-section precision (use L2)
 - Need WebGL shader or mesh deformation (use L3+)
 - Need real 3D camera and lit geometry (use L4)
-- Non-React project with no appetite for Motion — prefer CSS transitions or GSAP
 
 **Do not use for**
 
@@ -129,7 +177,7 @@ Escalation requires a **written reason** tied to Motion DNA, not "it would look 
 - Scroll-scrubbed or pinned section narrative is **required**
 - Multi-element timeline with precise sequencing (>3 chained beats on one trigger)
 - Horizontal scroll gallery with snap and progress sync
-- Vanilla HTML preview without React
+- Vanilla HTML preview without a declarative motion library — **or** Web stack where L1 CSS is insufficient
 
 **Reject when**
 
@@ -166,7 +214,7 @@ Escalation requires a **written reason** tied to Motion DNA, not "it would look 
 
 ---
 
-### L4 — Three.js / R3F
+### L4 — Three.js family
 
 **Choose when**
 
@@ -184,9 +232,9 @@ Escalation requires a **written reason** tied to Motion DNA, not "it would look 
 **Do not use for**
 
 - Default rotating cube / torus / particle field
-- Copying drei `Float`, `Stars`, or example boilerplate without DNA-driven art direction
+- Copying drei / cientos `Float`, `Stars`, or example boilerplate without DNA-driven art direction
 
-## Step 5 — Dependency check
+## Step 6 — Dependency check
 
 Run before locking an engine. If a check fails, **downgrade tier** or switch to static fallback.
 
@@ -198,55 +246,60 @@ Run before locking an engine. If a check fails, **downgrade tier** or switch to 
 | Page type fit | Motion density ≤ archetype allowance | Remove atmosphere; keep feedback only |
 | Single engine | No second runtime planned | Remove extra library |
 | Token binding | Durations/easing from design tokens | Remap; no library defaults |
+| Stack family | Detected `web` / `react` / `vue` | Ask once, or default `web` for standalone HTML previews |
 
-### L1 Motion
+### L1 by stack
 
-| Check | How |
-|-------|-----|
-| React available | `package.json` has `react` + `motion` or `framer-motion`, or preview uses React CDN |
-| SSR | Use `LazyMotion` + `domAnimation` or client-only boundary in Next.js |
-| Bundle | One motion feature slice; avoid importing entire motion-plus |
+| Stack | Check |
+|-------|-------|
+| **web** | Prefer CSS variables for duration/easing; if using vanilla `motion`, confirm package or CDN; no React/Vue imports in static HTML |
+| **react** | `react` + `motion` or `framer-motion`; Next.js → `LazyMotion` / client boundary; avoid importing entire motion-plus |
+| **vue** | `vue` ≥ 3 + `motion-v` **or** existing `@vueuse/motion`; Nuxt → `motion-v/nuxt` module or client-only plugin; do not install both Motion Vue libraries |
 
-### L2 GSAP
+### L2 GSAP by stack
 
-| Check | How |
-|-------|-----|
-| License | GSAP standard license OK for target; note Club plugins only if user has them |
-| ScrollTrigger | Register plugin once; `gsap.context()` for React cleanup |
-| Reduced motion | `gsap.matchMedia('(prefers-reduced-motion: reduce)')` → set duration 0 or opacity-only |
-| Mobile scroll | Avoid heavy scrub on long pinned sections; cap pin duration |
+| Stack | Check |
+|-------|-------|
+| **all** | GSAP standard license OK; Club plugins (Flip, SplitText) only if user has them |
+| **web** | Register ScrollTrigger once; kill tweens on page teardown |
+| **react** | `useGSAP` or `gsap.context` + cleanup; no duplicate ScrollTrigger registrations |
+| **vue** | Create animations in `onMounted`; `gsap.context(el)` + `ctx.revert()` in `onUnmounted` |
+| **a11y** | `gsap.matchMedia('(prefers-reduced-motion: reduce)')` → duration 0 or opacity-only |
+| **mobile** | Avoid heavy scrub on long pinned sections; cap pin duration |
 
-### L3 OGL
+### L3 OGL by stack
 
-| Check | How |
-|-------|-----|
-| WebGL | `canvas.getContext('webgl')` or WebGL2; fallback image/CSS |
-| DPR cap | `Math.min(devicePixelRatio, 2)` on mobile |
-| Resize | Listener + cancel animation on unmount |
-| Memory | Dispose programs/textures on route change |
+| Stack | Check |
+|-------|-------|
+| **all** | WebGL context available; DPR `Math.min(devicePixelRatio, 2)` on mobile; dispose on unmount |
+| **react** | Client-only component; cancel RAF on unmount |
+| **vue** | `ref` canvas; init in `onMounted`; dispose program/geometry/textures in `onBeforeUnmount` |
+| **web** | Same dispose discipline on `pagehide` / navigation |
 
-### L4 Three.js / R3F
+### L4 Three.js family by stack
 
-| Check | How |
-|-------|-----|
-| Packages | `three`, `@react-three/fiber`; `drei` only for justified helpers |
-| Canvas budget | ≤1 Canvas per surface; limit lights and postprocessing |
-| Mobile | Reduce geometry, shadow off, cap DPR; offer static poster |
-| SSR | `dynamic(..., { ssr: false })` for Canvas |
-| Reduced motion | Pause render loop or show poster frame |
+| Stack | Check |
+|-------|-------|
+| **web** | `three` only; ≤1 renderer; dispose geometries/materials/renderer |
+| **react** | `three` + `@react-three/fiber`; `drei` only when justified; `dynamic(..., { ssr: false })` in Next.js |
+| **vue** | `three` + `@tresjs/core`; Vite needs Tres `templateCompilerOptions`; `@tresjs/cientos` only when justified; Nuxt may use `@tresjs/nuxt` |
+| **all** | ≤1 Canvas/renderer per surface; mobile: lower poly, shadows off, DPR cap, static poster; reduced-motion → poster / pause loop |
 
 ### Dependency check output (agent must emit)
 
 ```yaml
 motion_engine_decision:
   motion_dna_summary: "medium tempo, calm easing, minimal density, feedback+guidance"
+  stack_family: react   # web | react | vue
+  stack_signals: ["next", "react", "shadcn"]
   selected_tier: L1
   selected_engine: motion
+  stack_binding: "motion@12"   # e.g. css-tokens | motion | framer-motion | motion-v | @vueuse/motion | gsap | ogl | three | r3f | tresjs
   escalation_reason: null
   rejected_tiers: [L2, L3, L4]
   rejection_notes: "No scroll-scrub narrative; dashboard page type"
   dependencies_ok: true
-  dependency_notes: ["motion@12 present", "LazyMotion for SSR"]
+  dependency_notes: ["motion present", "LazyMotion for SSR"]
   primary_recipe: "in-view-stagger"
   secondary_recipe: null
   decorative_budget: none
@@ -254,38 +307,52 @@ motion_engine_decision:
   mobile_strategy: transform-none; opacity-only under 768px for atmosphere
 ```
 
-## Step 6 — Recipes (minimal high-frequency)
+## Step 7 — Recipes (minimal high-frequency)
 
 Pick **one primary recipe**. Add **at most one** secondary recipe only if roles span feedback + guidance and both are token-light.
 
-### L1 — Motion recipes
+Recipes are **capability patterns**. Implement them with the stack binding from Step 3 — do not copy React JSX into Vue SFCs.
+
+### L1 recipes
 
 #### R1 — In-view stagger (`in-view-stagger`)
 
 - **Role**: guidance
 - **Trigger**: in-view (once)
-- **Pattern**: parent `staggerChildren` 0.06–0.12s; child `opacity` 0→1 + `y` 8–16px (from `--motion-distance-md`)
+- **Pattern**: parent stagger 0.06–0.12s; child opacity 0→1 + y 8–16px (from `--motion-distance-md`)
 - **Page types**: landing sections, marketing lists, editorial
 - **Reduced**: opacity only, stagger 0
 - **Mobile**: same; cap distance to `--motion-distance-sm`
+- **Bindings**:
+  - **web**: CSS `@keyframes` + `animation-delay` per child, or vanilla `motion` stagger
+  - **react**: `staggerChildren` / variants on `motion.*`
+  - **vue**: `motion-v` variants / stagger; or `@vueuse/motion` `v-motion` + delay per item
 
 #### R2 — Shared layout transition (`layout-handoff`)
 
 - **Role**: explanation
 - **Trigger**: state-change (tab, filter, route segment)
-- **Pattern**: `layoutId` on shared element; `transition` from `--duration-normal` + `--ease-default`
+- **Pattern**: shared-element or layout interpolation; duration `--duration-normal` + `--ease-default`
 - **Page types**: consumer app tabs, settings panels, segmented controls
 - **Reduced**: crossfade without layout interpolation
 - **Mobile**: prefer opacity morph; avoid large shared-element flights
+- **Bindings**:
+  - **web**: View Transitions API when enough; else crossfade CSS — do not fake FLIP with GSAP unless escalated to L2
+  - **react**: `layoutId` on `motion.*`
+  - **vue**: `motion-v` layout / shared layout APIs; if only `@vueuse/motion`, degrade to crossfade (no fake layoutId)
 
 #### R3 — Tactile press (`tap-feedback`)
 
 - **Role**: feedback
 - **Trigger**: click / tap
-- **Pattern**: `whileTap={{ scale: 0.97 }}` + optional `whileHover` lift 2px; duration `--duration-fast`
+- **Pattern**: press scale ~0.97 + optional hover lift 2px; duration `--duration-fast`
 - **Page types**: consumer app, forms, CTAs
 - **Reduced**: instant state change or border-color only
 - **Mobile**: default for all touch targets; no hover-dependent behavior
+- **Bindings**:
+  - **web**: `:active { transform: scale(0.97) }` + transition
+  - **react**: `whileTap` / `whileHover` on `motion.*`
+  - **vue**: `motion-v` tap/hover gestures; or CSS `:active` if staying dependency-free
 
 ---
 
@@ -298,7 +365,8 @@ Pick **one primary recipe**. Add **at most one** secondary recipe only if roles 
 - **Pattern**: ScrollTrigger scrub 0.5–1.5; section children fade + y tied to scroll progress; one pinned block max
 - **Page types**: brand story, launch narrative
 - **Reduced**: trigger once on enter, no scrub; or static layout
-- **Mobile**: shorten pin; reduce scrub sensitivity; prefer R1 Motion in-view instead if jank
+- **Mobile**: shorten pin; reduce scrub sensitivity; prefer L1 in-view instead if jank
+- **Bindings**: same GSAP API on web/react/vue — differ only in lifecycle (`useGSAP` vs `onMounted`/`revert`)
 
 #### R2 — Timeline entrance (`load-timeline`)
 
@@ -330,6 +398,7 @@ Pick **one primary recipe**. Add **at most one** secondary recipe only if roles 
 - **Page types**: landing, brand hero background
 - **Reduced**: static CSS `linear-gradient` from same tokens
 - **Mobile**: DPR cap 1.5; pause when `document.hidden`; static fallback under `prefers-reduced-motion`
+- **Bindings**: vanilla OGL in all families; wrap only for mount/unmount
 
 #### R2 — Image plane warp (`pointer-warp`)
 
@@ -351,7 +420,7 @@ Pick **one primary recipe**. Add **at most one** secondary recipe only if roles 
 
 ---
 
-### L4 — Three.js / R3F recipes
+### L4 — Three.js family recipes
 
 #### R1 — Product orbit (`product-orbit`)
 
@@ -361,6 +430,10 @@ Pick **one primary recipe**. Add **at most one** secondary recipe only if roles 
 - **Page types**: product launch, configurable hero
 - **Reduced**: poster image + drag disabled
 - **Mobile**: lower poly; no shadows; drag only if essential
+- **Bindings**:
+  - **web**: `three` + `OrbitControls` if needed
+  - **react**: R3F `<Canvas>` + mesh; avoid default `Float`/`Stars`
+  - **vue**: TresJS `<TresCanvas>` + mesh; avoid default cientos spectacle helpers
 
 #### R2 — Scroll camera (`scroll-camera-path`)
 
@@ -380,7 +453,7 @@ Pick **one primary recipe**. Add **at most one** secondary recipe only if roles 
 - **Reduced**: accordion of static images per hotspot
 - **Mobile**: tap hotspots; limit to 3 views
 
-## Step 7 — Mobile & reduced-motion fallbacks
+## Step 8 — Mobile & reduced-motion fallbacks
 
 Apply **both** branches to every implementation.
 
@@ -395,10 +468,12 @@ Apply **both** branches to every implementation.
 
 Engine-specific:
 
-- **Motion**: `useReducedMotion()` → skip `transform` variants
+- **L1 web**: CSS media query zeroes duration / distance tokens
+- **L1 react**: `useReducedMotion()` → skip `transform` variants
+- **L1 vue**: `useReducedMotion` from `motion-v` / matchMedia; or CSS media query with `@vueuse/motion`
 - **GSAP**: `matchMedia` context with `duration: 0` or simplified tweens
 - **OGL**: detach RAF; swap canvas for CSS/static image
-- **R3F**: render poster frame; unmount Canvas when `reduce`
+- **R3F / TresJS / three**: poster frame; pause or unmount renderer when `reduce`
 
 ### Mobile
 
@@ -410,27 +485,30 @@ Engine-specific:
 | Safe areas | Motion must not shift fixed nav / notches; test 390×844 |
 | Connection / CPU | Prefer L1; lazy-load L3/L4 after first paint with poster |
 
-## Step 8 — Anti-patterns (reject automatically)
+## Step 9 — Anti-patterns (reject automatically)
 
 | Anti-pattern | Why | Instead |
 |--------------|-----|---------|
 | Motion + GSAP on same page | Double runtime, inconsistent easing | One engine |
+| React `motion` inside a Vue SFC (or vice versa) | Wrong stack binding | Use `motion-v` / `@vueuse/motion` on Vue |
+| `motion-v` + `@vueuse/motion` together | Duplicate L1 runtimes | Keep the one already in the project |
 | GSAP + OGL scroll both scrubbing | Stacked scroll listeners | One scroll driver |
-| R3F background + GSAP parallax + Motion text stagger | Triple decorative stack | Pick one atmosphere recipe |
-| `Float` + `Stars` + bloom defaults | Demo cosplay | DNA-driven single effect |
+| R3F/Tres background + GSAP parallax + L1 text stagger | Triple decorative stack | Pick one atmosphere recipe |
+| `Float` + `Stars` + bloom defaults (drei/cientos) | Demo cosplay | DNA-driven single effect |
 | Elastic easing on tables/forms | Breaks scanability | calm + fast, small distance |
 | Infinite hero loops | Accessibility + distraction | once or pausable |
 | 3D on B-end dashboard | Page type violation | L1 feedback only |
+| Forcing GSAP because a blog post used it | Ignores simplest-sufficient rule | Stay on L1 when DNA fits |
 
 ## Agent workflow (when implementing)
 
 1. Read confirmed Motion DNA from design system or exploration output
 2. **Load this file** (progressive load — not before)
-3. Run capability check → dependency check → select tier
-4. Emit `motion_engine_decision` YAML (see Step 5)
-5. Implement **one primary recipe** with token-bound durations/easing
+3. Run capability check → **detect stack family** → dependency check → select tier + binding
+4. Emit `motion_engine_decision` YAML (see Step 6) including `stack_family` and `stack_binding`
+5. Implement **one primary recipe** with token-bound durations/easing in the correct stack idiom
 6. Wire `prefers-reduced-motion` and mobile fallback
-7. Self-review: page type, single engine, no demo aesthetics, no stacked atmosphere
+7. Self-review: page type, single engine, correct stack binding, no demo aesthetics, no stacked atmosphere
 
 ## Related references
 

--- a/references/MOTION-ENGINE-ROUTER.md
+++ b/references/MOTION-ENGINE-ROUTER.md
@@ -1,0 +1,440 @@
+# Motion Engine Router
+
+Progressive-load reference. **Do not read this file during vibe exploration, mood boards, or token extraction.** Load it only when the agent is about to **implement motion in code** (preview HTML, concept page, or project Apply) and has already produced Motion DNA from [MOTION-SYSTEM.md](MOTION-SYSTEM.md).
+
+## Purpose
+
+Turn the user's vibe and confirmed Motion DNA into **one** implementation engine and **one** minimal recipe set. The router exists so agents:
+
+1. Express the target feeling with the **simplest technology that can carry it**
+2. **Never mix engines** on the same surface
+3. **Never stack** decorative effects (parallax + particles + 3D + scroll scrub on the same hero)
+4. **Never copy** library default demo aesthetics (generic floating shapes, stock purple gradients, boilerplate particle fields)
+
+## Router pipeline
+
+```
+User vibe / reference / music
+        ↓
+Motion DNA (8 dimensions + narrative from MOTION-SYSTEM.md)
+        ↓
+Capability check (what must be expressed?)
+        ↓
+Dependency audit (project + device + a11y)
+        ↓
+Engine selection (exactly one: L1–L4)
+        ↓
+Recipe pick (1 primary + at most 1 supporting pattern)
+        ↓
+Implement with tokens + fallbacks
+```
+
+## Non-negotiable rules
+
+| Rule | Requirement |
+|------|-------------|
+| **One engine per surface** | A page, screen, or preview artifact uses **one** engine tier. Shared layout CSS transitions are allowed; do not add a second animation runtime. |
+| **Simplest sufficient layer** | Start at L1 (Motion). Escalate only when L1 cannot express a **required** capability (see ladder below). |
+| **One decorative motion budget** | At most **one** atmosphere-class effect per surface (role = atmosphere in Motion DNA). Feedback and guidance patterns are separate and stay minimal. |
+| **No demo cosplay** | Do not reproduce official examples (Framer Motion layout demos, GSAP ScrollSmoother defaults, Three.js particle fields, shader toy noise). Derive motion from **Motion DNA + design tokens**. |
+| **Page type wins** | B-end / dense surfaces default to L1 or CSS-only. Landing / brand may reach L2–L4 only when atmosphere is an explicit design goal. |
+| **Reduced motion first-class** | Every recipe ships with a `prefers-reduced-motion` branch before shipping. |
+| **Mobile honesty** | If the chosen recipe cannot hold 60fps on mid-tier mobile, downgrade engine tier or switch to static / simplified fallback — do not ship jank. |
+
+## Step 1 — Compile Motion DNA from vibe
+
+Use the eight dimensions in [MOTION-SYSTEM.md](MOTION-SYSTEM.md). When the user gives only a vibe (no reference), map signals into this **compiled record** before choosing an engine:
+
+| Field | Source | Example |
+|-------|--------|---------|
+| `roles[]` | Which motion roles are required | `["feedback", "guidance"]` |
+| `triggers[]` | What fires motion | `["in-view", "hover", "state-change"]` |
+| `tempo` | slow / medium / fast | `medium` |
+| `easing` | calm / sharp / elastic | `calm` |
+| `distance` | small / medium / large | `small` |
+| `density` | minimal / moderate / rich | `minimal` |
+| `repeat` | once / every-trigger / loop | `every-trigger` |
+| `reduced_strategy` | fade / static / simplified / pausable | `fade` |
+| `personality` | narrative layer | `reliable & composed` |
+| `page_metaphor` | product manual / launch / dashboard / story / showcase | `dashboard` |
+| `primary_intent` | understanding / excitement | `understanding` |
+
+### Vibe word → DNA shortcuts
+
+| User says | DNA bias |
+|-----------|----------|
+| calm, zen, minimal, trustworthy | slow–medium tempo, calm easing, minimal density, small distance, feedback-only roles |
+| snappy, fast, cutting-edge | fast tempo, sharp easing, medium density, state-change heavy |
+| playful, bouncy, fun | medium–fast tempo, elastic easing, moderate density, emphasis + feedback |
+| premium, cinematic, luxurious | slow tempo, calm easing, rich density, large distance, atmosphere allowed |
+| editorial, story, guided | medium tempo, guidance role, in-view + scroll triggers, staggered once |
+| tactile, app-like | fast tempo, small distance, click/tap + state-change, **L1 only** unless 3D product viewer |
+
+Music signals (when provided): BPM → tempo; dynamics → distance; rhythm → stagger; texture → density; energy → easing.
+
+## Step 2 — Capability check
+
+Ask: **What is the minimum expressiveness required?**
+
+| Required capability | Minimum tier |
+|--------------------|--------------|
+| Hover / tap feedback, enter/exit, layout morph, modal, tab, list stagger | **L1 Motion** |
+| Scroll-scrubbed narrative, pinned sections, complex multi-step timeline, horizontal scroll choreography | **L2 GSAP** |
+| Full-screen shader atmosphere, 2D WebGL image warp, lightweight GPU gradient/noise tied to scroll or pointer | **L3 OGL** |
+| True 3D object, camera path, lighting on mesh, interactive orbit, spatial product hero | **L4 Three.js / R3F** |
+
+If multiple rows match, pick the **lowest** tier that covers all **functional** requirements. Atmosphere alone never justifies L4.
+
+## Step 3 — Engine ladder
+
+| Tier | Engine | Runtime | Typical stack |
+|------|--------|---------|---------------|
+| **L1** | **Motion** (`motion` / `framer-motion`) | React declarative | Next.js, Vite + React |
+| **L2** | **GSAP** (+ ScrollTrigger when needed) | Imperative timeline | Any DOM; React use `useGSAP` / `gsap.context` |
+| **L3** | **OGL** | Minimal WebGL | Vanilla or React wrapper; no full scene graph |
+| **L4** | **Three.js** / **React Three Fiber** | Full 3D | `@react-three/fiber` + `@react-three/drei` when in React |
+
+Escalation requires a **written reason** tied to Motion DNA, not "it would look cool."
+
+## Step 4 — Selection & rejection matrix
+
+### L1 — Motion
+
+**Choose when**
+
+- React (or preview HTML with React CDN) is the implementation surface
+- Motion roles are feedback, guidance, explanation with DOM/CSS-friendly transforms
+- Density is minimal or moderate
+- Consumer app tactile patterns (press, sheet, tab indicator)
+- Page metaphor is product manual, dashboard, or form
+
+**Reject when**
+
+- Scroll position must drive animation progress with sub-section precision (use L2)
+- Need WebGL shader or mesh deformation (use L3+)
+- Need real 3D camera and lit geometry (use L4)
+- Non-React project with no appetite for Motion — prefer CSS transitions or GSAP
+
+**Do not use for**
+
+- Long pinned scroll stories (GSAP territory)
+- Full-viewport GPU backgrounds (OGL territory)
+
+---
+
+### L2 — GSAP
+
+**Choose when**
+
+- Scroll-scrubbed or pinned section narrative is **required**
+- Multi-element timeline with precise sequencing (>3 chained beats on one trigger)
+- Horizontal scroll gallery with snap and progress sync
+- Vanilla HTML preview without React
+
+**Reject when**
+
+- Only need hover, tap, and simple in-view fade (L1 or CSS is enough)
+- Effect is purely shader/GPU (L3)
+- Effect is 3D mesh (L4)
+- Page type is dense B-end workbench — scroll choreography usually **fails** page-type fit
+
+**Do not use for**
+
+- Button hover micro-interactions (overkill)
+- Default ScrollSmoother + generic parallax stack
+
+---
+
+### L3 — OGL
+
+**Choose when**
+
+- Atmosphere role needs GPU gradient, noise, or subtle distortion **without** a 3D scene
+- Image warp / reveal tied to pointer or scroll on a **single** plane or quad
+- Performance-sensitive full-bleed background where CSS cannot match the material DNA
+
+**Reject when**
+
+- DOM-only motion suffices
+- Need rigged 3D models or camera orbit (L4)
+- User is on low WebGL adoption risk and atmosphere is optional — use CSS + static image instead
+
+**Do not use for**
+
+- Particle galaxy demos
+- Replacing all L1 feedback animations
+
+---
+
+### L4 — Three.js / R3F
+
+**Choose when**
+
+- Product or hero **requires** readable 3D geometry, lighting, or camera movement
+- Spatial metaphor is explicitly showcase / launch **and** 3D is content, not wallpaper
+- User confirmed WebGL weight for their page type
+
+**Reject when**
+
+- 2D layout motion or shader plane is enough (L1–L3)
+- B-end, docs, or dense table surfaces
+- No `webgl` or device is mobile-low-tier without fallback asset
+- Atmosphere-only brief — never use L4 for decoration alone
+
+**Do not use for**
+
+- Default rotating cube / torus / particle field
+- Copying drei `Float`, `Stars`, or example boilerplate without DNA-driven art direction
+
+## Step 5 — Dependency check
+
+Run before locking an engine. If a check fails, **downgrade tier** or switch to static fallback.
+
+### Universal checks
+
+| Check | Pass | Fail action |
+|-------|------|-------------|
+| `prefers-reduced-motion: reduce` | Fallback defined | Do not ship until branch exists |
+| Page type fit | Motion density ≤ archetype allowance | Remove atmosphere; keep feedback only |
+| Single engine | No second runtime planned | Remove extra library |
+| Token binding | Durations/easing from design tokens | Remap; no library defaults |
+
+### L1 Motion
+
+| Check | How |
+|-------|-----|
+| React available | `package.json` has `react` + `motion` or `framer-motion`, or preview uses React CDN |
+| SSR | Use `LazyMotion` + `domAnimation` or client-only boundary in Next.js |
+| Bundle | One motion feature slice; avoid importing entire motion-plus |
+
+### L2 GSAP
+
+| Check | How |
+|-------|-----|
+| License | GSAP standard license OK for target; note Club plugins only if user has them |
+| ScrollTrigger | Register plugin once; `gsap.context()` for React cleanup |
+| Reduced motion | `gsap.matchMedia('(prefers-reduced-motion: reduce)')` → set duration 0 or opacity-only |
+| Mobile scroll | Avoid heavy scrub on long pinned sections; cap pin duration |
+
+### L3 OGL
+
+| Check | How |
+|-------|-----|
+| WebGL | `canvas.getContext('webgl')` or WebGL2; fallback image/CSS |
+| DPR cap | `Math.min(devicePixelRatio, 2)` on mobile |
+| Resize | Listener + cancel animation on unmount |
+| Memory | Dispose programs/textures on route change |
+
+### L4 Three.js / R3F
+
+| Check | How |
+|-------|-----|
+| Packages | `three`, `@react-three/fiber`; `drei` only for justified helpers |
+| Canvas budget | ≤1 Canvas per surface; limit lights and postprocessing |
+| Mobile | Reduce geometry, shadow off, cap DPR; offer static poster |
+| SSR | `dynamic(..., { ssr: false })` for Canvas |
+| Reduced motion | Pause render loop or show poster frame |
+
+### Dependency check output (agent must emit)
+
+```yaml
+motion_engine_decision:
+  motion_dna_summary: "medium tempo, calm easing, minimal density, feedback+guidance"
+  selected_tier: L1
+  selected_engine: motion
+  escalation_reason: null
+  rejected_tiers: [L2, L3, L4]
+  rejection_notes: "No scroll-scrub narrative; dashboard page type"
+  dependencies_ok: true
+  dependency_notes: ["motion@12 present", "LazyMotion for SSR"]
+  primary_recipe: "in-view-stagger"
+  secondary_recipe: null
+  decorative_budget: none
+  reduced_motion_strategy: fade
+  mobile_strategy: transform-none; opacity-only under 768px for atmosphere
+```
+
+## Step 6 — Recipes (minimal high-frequency)
+
+Pick **one primary recipe**. Add **at most one** secondary recipe only if roles span feedback + guidance and both are token-light.
+
+### L1 — Motion recipes
+
+#### R1 — In-view stagger (`in-view-stagger`)
+
+- **Role**: guidance
+- **Trigger**: in-view (once)
+- **Pattern**: parent `staggerChildren` 0.06–0.12s; child `opacity` 0→1 + `y` 8–16px (from `--motion-distance-md`)
+- **Page types**: landing sections, marketing lists, editorial
+- **Reduced**: opacity only, stagger 0
+- **Mobile**: same; cap distance to `--motion-distance-sm`
+
+#### R2 — Shared layout transition (`layout-handoff`)
+
+- **Role**: explanation
+- **Trigger**: state-change (tab, filter, route segment)
+- **Pattern**: `layoutId` on shared element; `transition` from `--duration-normal` + `--ease-default`
+- **Page types**: consumer app tabs, settings panels, segmented controls
+- **Reduced**: crossfade without layout interpolation
+- **Mobile**: prefer opacity morph; avoid large shared-element flights
+
+#### R3 — Tactile press (`tap-feedback`)
+
+- **Role**: feedback
+- **Trigger**: click / tap
+- **Pattern**: `whileTap={{ scale: 0.97 }}` + optional `whileHover` lift 2px; duration `--duration-fast`
+- **Page types**: consumer app, forms, CTAs
+- **Reduced**: instant state change or border-color only
+- **Mobile**: default for all touch targets; no hover-dependent behavior
+
+---
+
+### L2 — GSAP recipes
+
+#### R1 — Scroll-scrubbed reveal (`scrub-section-reveal`)
+
+- **Role**: guidance
+- **Trigger**: scroll
+- **Pattern**: ScrollTrigger scrub 0.5–1.5; section children fade + y tied to scroll progress; one pinned block max
+- **Page types**: brand story, launch narrative
+- **Reduced**: trigger once on enter, no scrub; or static layout
+- **Mobile**: shorten pin; reduce scrub sensitivity; prefer R1 Motion in-view instead if jank
+
+#### R2 — Timeline entrance (`load-timeline`)
+
+- **Role**: emphasis + guidance
+- **Trigger**: page-load (once)
+- **Pattern**: single `timeline` ≤1.2s total; hero headline → subcopy → CTA stagger; no looping
+- **Page types**: landing hero
+- **Reduced**: show final state; optional 150ms opacity fade total
+- **Mobile**: cut distance 50%; max 3 tweens
+
+#### R3 — Horizontal chapter (`horizontal-scroll-chapter`)
+
+- **Role**: guidance + atmosphere
+- **Trigger**: scroll
+- **Pattern**: pinned container + horizontal `xPercent`; snap optional; progress indicator tied to tokens
+- **Page types**: showcase, portfolio story
+- **Reduced**: vertical stack static sections
+- **Mobile**: **avoid** unless content demands; fallback to vertical narrative
+
+---
+
+### L3 — OGL recipes
+
+#### R1 — Token gradient field (`shader-atmosphere`)
+
+- **Role**: atmosphere
+- **Trigger**: auto-play (slow) + optional pointer parallax ≤8px
+- **Pattern**: full-bleed quad; fragment colors sampled from CSS token hex; low-frequency noise; no particles
+- **Page types**: landing, brand hero background
+- **Reduced**: static CSS `linear-gradient` from same tokens
+- **Mobile**: DPR cap 1.5; pause when `document.hidden`; static fallback under `prefers-reduced-motion`
+
+#### R2 — Image plane warp (`pointer-warp`)
+
+- **Role**: atmosphere + emphasis
+- **Trigger**: hover or pointer move
+- **Pattern**: single texture quad; subtle UV displacement; strengths from `--motion-distance-sm`
+- **Page types**: product showcase, editorial hero image
+- **Reduced**: static image
+- **Mobile**: disable warp; use static or light CSS scale on tap
+
+#### R3 — Scroll-linked displacement (`scroll-displace`)
+
+- **Role**: atmosphere
+- **Trigger**: scroll
+- **Pattern**: displacement strength tied to scroll 0–1; one uniform; no extra meshes
+- **Page types**: immersive landing
+- **Reduced**: parallax off; static frame
+- **Mobile**: prefer static; scroll-linked GPU on low-end → static
+
+---
+
+### L4 — Three.js / R3F recipes
+
+#### R1 — Product orbit (`product-orbit`)
+
+- **Role**: explanation + emphasis
+- **Trigger**: auto-play slow orbit + drag optional
+- **Pattern**: one mesh or imported GLTF; lighting from art direction; background matches `--color-background`; no stock helpers
+- **Page types**: product launch, configurable hero
+- **Reduced**: poster image + drag disabled
+- **Mobile**: lower poly; no shadows; drag only if essential
+
+#### R2 — Scroll camera (`scroll-camera-path`)
+
+- **Role**: guidance + atmosphere
+- **Trigger**: scroll
+- **Pattern**: camera `position`/`lookAt` lerped along curve; ≤3 key poses; sync with DOM sections
+- **Page types**: showcase narrative
+- **Reduced**: single hero angle; DOM scroll normal
+- **Mobile**: replace with R1 short orbit or static poster unless user insists
+
+#### R3 — Interactive focus (`focus-orbit`)
+
+- **Role**: explanation
+- **Trigger**: click / tap hotspots
+- **Pattern**: camera tween to predefined views; hotspot labels in DOM overlay
+- **Page types**: feature explorer, 3D configurator lite
+- **Reduced**: accordion of static images per hotspot
+- **Mobile**: tap hotspots; limit to 3 views
+
+## Step 7 — Mobile & reduced-motion fallbacks
+
+Apply **both** branches to every implementation.
+
+### Reduced-motion (`prefers-reduced-motion: reduce`)
+
+| Strategy | Implementation |
+|----------|----------------|
+| **fade** (default) | Remove transforms; opacity 0→1 ≤200ms or instant |
+| **static** | Final keyframe state immediately; no loop |
+| **simplified** | Keep meaning-bearing motion (e.g. progress); remove parallax and atmosphere |
+| **pausable** | `animation-play-state` + visible control for loops |
+
+Engine-specific:
+
+- **Motion**: `useReducedMotion()` → skip `transform` variants
+- **GSAP**: `matchMedia` context with `duration: 0` or simplified tweens
+- **OGL**: detach RAF; swap canvas for CSS/static image
+- **R3F**: render poster frame; unmount Canvas when `reduce`
+
+### Mobile
+
+| Risk | Mitigation |
+|------|------------|
+| Scroll jank (L2/L3/L4) | Downgrade recipe; shorten pin; static fallback |
+| WebGL thermal throttling | Cap DPR; pause off-screen; static hero image |
+| Touch vs hover | All hover recipes need tap-equivalent or run once on reveal |
+| Safe areas | Motion must not shift fixed nav / notches; test 390×844 |
+| Connection / CPU | Prefer L1; lazy-load L3/L4 after first paint with poster |
+
+## Step 8 — Anti-patterns (reject automatically)
+
+| Anti-pattern | Why | Instead |
+|--------------|-----|---------|
+| Motion + GSAP on same page | Double runtime, inconsistent easing | One engine |
+| GSAP + OGL scroll both scrubbing | Stacked scroll listeners | One scroll driver |
+| R3F background + GSAP parallax + Motion text stagger | Triple decorative stack | Pick one atmosphere recipe |
+| `Float` + `Stars` + bloom defaults | Demo cosplay | DNA-driven single effect |
+| Elastic easing on tables/forms | Breaks scanability | calm + fast, small distance |
+| Infinite hero loops | Accessibility + distraction | once or pausable |
+| 3D on B-end dashboard | Page type violation | L1 feedback only |
+
+## Agent workflow (when implementing)
+
+1. Read confirmed Motion DNA from design system or exploration output
+2. **Load this file** (progressive load — not before)
+3. Run capability check → dependency check → select tier
+4. Emit `motion_engine_decision` YAML (see Step 5)
+5. Implement **one primary recipe** with token-bound durations/easing
+6. Wire `prefers-reduced-motion` and mobile fallback
+7. Self-review: page type, single engine, no demo aesthetics, no stacked atmosphere
+
+## Related references
+
+- Motion DNA dimensions & extraction: [MOTION-SYSTEM.md](MOTION-SYSTEM.md)
+- Token output shape: [../assets/design-system-template.md](../assets/design-system-template.md) § Motion System
+- Consumer app tactile patterns: [CONSUMER-APP-DESIGN.md](CONSUMER-APP-DESIGN.md)
+- Page type constraints: [SKILL.md](../SKILL.md) § Stage 0

--- a/references/MOTION-ENGINE-ROUTER.md
+++ b/references/MOTION-ENGINE-ROUTER.md
@@ -1,16 +1,17 @@
 # Motion Engine Router
 
-Progressive-load reference. **Do not read this file during vibe exploration, mood boards, or token extraction.** Load it only when the agent is about to **implement motion in code** (preview HTML, concept page, or project Apply) and has already produced Motion DNA from [MOTION-SYSTEM.md](MOTION-SYSTEM.md).
+Progressive-load reference. **Do not read this file during vibe exploration, mood boards, or token extraction.** For exploration HTML motion, use **Exploration Interim Motion** in [SKILL.md](../SKILL.md) (CSS + provisional DNA + signature motif). Load this file only when the agent is about to **implement production-grade motion in code** (design-system preview, productionized concept, or project Apply) and has already produced Motion DNA + signature motif from [MOTION-SYSTEM.md](MOTION-SYSTEM.md).
 
 ## Purpose
 
-Turn the user's vibe and confirmed Motion DNA into **one** implementation engine, **one** stack binding, and **one** minimal recipe set. The router exists so agents:
+Turn the user's vibe and confirmed Motion DNA into **one** implementation engine, **one** stack binding, and **one** minimal recipe set — then **mutate** that recipe with the signature motif so the result feels like the user's references, not a correct-but-generic template. The router exists so agents:
 
 1. Express the target feeling with the **simplest technology that can carry it**
 2. Bind that engine to the project's **Web / React / Vue** stack family — not a kitchen-sink multi-platform catalog
 3. **Never mix engines** on the same surface
 4. **Never stack** decorative effects (parallax + particles + 3D + scroll scrub on the same hero)
 5. **Never copy** library default demo aesthetics (generic floating shapes, stock purple gradients, boilerplate particle fields)
+6. **Break mediocrity gravity** — recipes are skeletons; DNA + signature motif must change defaults before shipping
 
 ## Product scope (what this router covers)
 
@@ -74,6 +75,21 @@ Use the eight dimensions in [MOTION-SYSTEM.md](MOTION-SYSTEM.md). When the user 
 | `personality` | narrative layer | `reliable & composed` |
 | `page_metaphor` | product manual / launch / dashboard / story / showcase | `dashboard` |
 | `primary_intent` | understanding / excitement | `understanding` |
+| `signature_motif` | One memorable motion idea from vibe/reference | `"soft paper settle: 12px rise, calm ease-out, 60ms stagger"` |
+
+### Signature motif (required)
+
+Before picking a recipe, write one sentence for `signature_motif`. It must be specific enough to change recipe defaults (distance, easing, stagger, which property moves). Reject motifs that are only "fade in" or "subtle hover."
+
+**Motif → parameter mutation examples**
+
+| Motif cue | Mutate |
+|-----------|--------|
+| soft / paper / calm | smaller distance, longer ease-out, gentler stagger |
+| snappy / tool / precise | shorter duration, sharp easing, near-zero overshoot |
+| playful / bounce | elastic only on **feedback** roles; keep guidance calm |
+| cinematic / premium | larger distance on hero only; everywhere else restrained |
+| music syncopation | uneven stagger (e.g. 40/80/40ms) instead of uniform 80ms |
 
 ### Vibe word → DNA shortcuts
 
@@ -290,6 +306,7 @@ Run before locking an engine. If a check fails, **downgrade tier** or switch to 
 ```yaml
 motion_engine_decision:
   motion_dna_summary: "medium tempo, calm easing, minimal density, feedback+guidance"
+  signature_motif: "soft paper settle: 12px rise, calm ease-out, 60ms stagger"
   stack_family: react   # web | react | vue
   stack_signals: ["next", "react", "shadcn"]
   selected_tier: L1
@@ -301,7 +318,8 @@ motion_engine_decision:
   dependencies_ok: true
   dependency_notes: ["motion present", "LazyMotion for SSR"]
   primary_recipe: "in-view-stagger"
-  secondary_recipe: null
+  secondary_recipe: "tap-feedback"  # only if feedback+guidance; else null
+  recipe_mutations: "distance 12px; stagger 60ms; ease calm — from signature_motif"
   decorative_budget: none
   reduced_motion_strategy: fade
   mobile_strategy: transform-none; opacity-only under 768px for atmosphere
@@ -309,7 +327,14 @@ motion_engine_decision:
 
 ## Step 7 — Recipes (minimal high-frequency)
 
-Pick **one primary recipe**. Add **at most one** secondary recipe only if roles span feedback + guidance and both are token-light.
+Pick **one primary recipe**. Add **at most one** secondary recipe **only** when both of these are true:
+
+1. Roles span **feedback + guidance** (e.g. tap-feedback + in-view-stagger, or tap-feedback + tab-indicator)
+2. Both recipes stay token-light (no atmosphere, no L2 scrub, no WebGL as secondary)
+
+**Never** use atmosphere, emphasis-only spectacle, or a second scroll/WebGL driver as a secondary recipe. If the surface needs atmosphere, that atmosphere recipe **is** the primary (and decorative budget is spent).
+
+Recipes are **capability skeletons**. After choosing one, **mutate** duration, easing, distance, and stagger from Motion DNA + `signature_motif`. Shipping the numeric defaults below unchanged is a mediocrity failure.
 
 Recipes are **capability patterns**. Implement them with the stack binding from Step 3 — do not copy React JSX into Vue SFCs.
 
@@ -319,7 +344,7 @@ Recipes are **capability patterns**. Implement them with the stack binding from 
 
 - **Role**: guidance
 - **Trigger**: in-view (once)
-- **Pattern**: parent stagger 0.06–0.12s; child opacity 0→1 + y 8–16px (from `--motion-distance-md`)
+- **Pattern**: parent stagger 0.06–0.12s; child opacity 0→1 + y 8–16px (from `--motion-distance-md`) — **override from motif**
 - **Page types**: landing sections, marketing lists, editorial
 - **Reduced**: opacity only, stagger 0
 - **Mobile**: same; cap distance to `--motion-distance-sm`
@@ -345,7 +370,7 @@ Recipes are **capability patterns**. Implement them with the stack binding from 
 
 - **Role**: feedback
 - **Trigger**: click / tap
-- **Pattern**: press scale ~0.97 + optional hover lift 2px; duration `--duration-fast`
+- **Pattern**: press scale ~0.97 + optional hover lift 2px; duration `--duration-fast` — scale/lift from motif
 - **Page types**: consumer app, forms, CTAs
 - **Reduced**: instant state change or border-color only
 - **Mobile**: default for all touch targets; no hover-dependent behavior
@@ -353,6 +378,34 @@ Recipes are **capability patterns**. Implement them with the stack binding from 
   - **web**: `:active { transform: scale(0.97) }` + transition
   - **react**: `whileTap` / `whileHover` on `motion.*`
   - **vue**: `motion-v` tap/hover gestures; or CSS `:active` if staying dependency-free
+
+#### R4 — Sheet rise (`sheet-rise`)
+
+- **Role**: explanation + guidance
+- **Trigger**: click / tap (open), dismiss gesture or backdrop (close)
+- **Pattern**: sheet enters from bottom (`y` 100%→0 or 24–48px rise + fade); duration 220–320ms from Consumer app guidance; controlled spring or calm ease-out per motif — **no full-screen bounce**
+- **Page types**: Consumer app detail/create flows, filters, confirmations
+- **Reduced**: instant show/hide or opacity-only; keep final state readable
+- **Mobile**: primary pattern; respect safe-area inset; backdrop fade without parallax stack
+- **Bindings**:
+  - **web**: CSS `@keyframes` / `transition` on transform + opacity; `role="dialog"`
+  - **react**: `motion` animate `y` + opacity; exit animation on unmount
+  - **vue**: `motion-v` enter/exit or CSS transition on `v-if` / `<Transition>`
+
+#### R5 — Tab indicator (`tab-indicator`)
+
+- **Role**: feedback + guidance
+- **Trigger**: click / tap (tab change)
+- **Pattern**: selected indicator slides or morphs to the active tab (layout handoff on the underline/pill only); content crossfades or short directional slide ≤12px; duration `--duration-fast`–`--duration-normal`
+- **Page types**: Consumer app bottom tabs, top tabs, segmented controls
+- **Reduced**: instant selection state; no sliding indicator required
+- **Mobile**: thumb-zone stable; do not animate the whole tab bar vertically
+- **Bindings**:
+  - **web**: indicator `transform: translateX(...)` with token easing
+  - **react**: `layoutId` on indicator only (prefer over animating all tab panels)
+  - **vue**: `motion-v` layout on indicator; or CSS transform on active index
+
+**Consumer app default pairing**: primary `sheet-rise` or `tab-indicator` as required by the screen; secondary `tap-feedback` only (feedback + guidance rule).
 
 ---
 
@@ -499,16 +552,33 @@ Engine-specific:
 | Infinite hero loops | Accessibility + distraction | once or pausable |
 | 3D on B-end dashboard | Page type violation | L1 feedback only |
 | Forcing GSAP because a blog post used it | Ignores simplest-sufficient rule | Stay on L1 when DNA fits |
+| Shipping recipe numeric defaults unchanged | Correct but mediocre | Mutate from `signature_motif` |
+| Uniform fade-up on every section | Generic LLM gravity | One motif; vary only where hierarchy needs it |
+| Exploration HTML with GSAP/Three CDN demos | Loads Router too early / demo cosplay | CSS interim motion + motif |
+
+## Step 10 — Break mediocrity gravity (self-review before ship)
+
+After implementing, answer **yes** to all before considering motion done:
+
+1. **Motif present** — Can you name the signature motif in one sentence, and does the code encode it (not only comments)?
+2. **Reference lineage** — Does at least one timing/distance/easing choice trace to the user's vibe, music, or UI reference?
+3. **Not template-identical** — If brand color/type were swapped, would the motion still feel distinct from a generic SaaS fade-up kit?
+4. **Recipe mutated** — Did duration, distance, or stagger differ from the recipe's printed defaults for a DNA reason?
+5. **Budget held** — Still one engine, ≤1 secondary (feedback+guidance only), ≤1 atmosphere effect?
+6. **A11y held** — Reduced-motion and mobile fallbacks still match the motif's *meaning* (state visible), not only "turn off"?
+
+If any answer is no, revise before showing the user.
 
 ## Agent workflow (when implementing)
 
-1. Read confirmed Motion DNA from design system or exploration output
-2. **Load this file** (progressive load — not before)
+1. Read confirmed Motion DNA + signature motif from design system or exploration output
+2. **Load this file** (progressive load — not during early exploration)
 3. Run capability check → **detect stack family** → dependency check → select tier + binding
-4. Emit `motion_engine_decision` YAML (see Step 6) including `stack_family` and `stack_binding`
-5. Implement **one primary recipe** with token-bound durations/easing in the correct stack idiom
-6. Wire `prefers-reduced-motion` and mobile fallback
-7. Self-review: page type, single engine, correct stack binding, no demo aesthetics, no stacked atmosphere
+4. Pick primary recipe (+ optional feedback+guidance secondary); **mutate** from motif
+5. Emit `motion_engine_decision` YAML (see Step 6) including `signature_motif` and `recipe_mutations`
+6. Implement with token-bound durations/easing in the correct stack idiom
+7. Wire `prefers-reduced-motion` and mobile fallback
+8. Pass Step 10 mediocrity self-review
 
 ## Related references
 
@@ -516,3 +586,4 @@ Engine-specific:
 - Token output shape: [../assets/design-system-template.md](../assets/design-system-template.md) § Motion System
 - Consumer app tactile patterns: [CONSUMER-APP-DESIGN.md](CONSUMER-APP-DESIGN.md)
 - Page type constraints: [SKILL.md](../SKILL.md) § Stage 0
+- Exploration Interim Motion: [SKILL.md](../SKILL.md) § Design Exploration

--- a/references/MOTION-SYSTEM.md
+++ b/references/MOTION-SYSTEM.md
@@ -195,16 +195,17 @@ Generate motion tokens as part of the design system output using the motion sect
 
 ## Motion Engine Router (progressive load)
 
-**During exploration and token extraction**, stop at Motion DNA + motion tokens. Do **not** load implementation libraries yet.
+**During exploration and token extraction**, stop at provisional/confirmed Motion DNA + motion tokens + signature motif. Do **not** load the full engine/package matrix yet. For exploration HTML, follow **Exploration Interim Motion** in [SKILL.md](../SKILL.md) (CSS-only, one signature motif).
 
-**When implementing motion in code** (standalone preview HTML, concept page, or Apply to project), progressively load [MOTION-ENGINE-ROUTER.md](MOTION-ENGINE-ROUTER.md) and run:
+**When implementing motion in code** (design-system preview, productionized concept, or Apply to project), progressively load [MOTION-ENGINE-ROUTER.md](MOTION-ENGINE-ROUTER.md) and run:
 
-1. **Compile Motion DNA** — finalize the eight dimensions plus narrative (`personality`, `page_metaphor`, `primary_intent`) from vibe, reference, music, and page type.
+1. **Compile Motion DNA** — finalize the eight dimensions plus narrative (`personality`, `page_metaphor`, `primary_intent`) and the **signature motion motif** from vibe, reference, music, and page type.
 2. **Capability check** — list only the expressiveness that is **required** (feedback, scroll narrative, shader atmosphere, true 3D, etc.).
 3. **Detect stack family** — `web` | `react` | `vue` (web-first scope; not RN/Flutter). Bind packages to that family (e.g. L1 → CSS/`motion` | `motion`/`framer-motion` | `motion-v`/`@vueuse/motion`; L4 → `three` | R3F | TresJS).
 4. **Select one engine tier** — L1 → L2 GSAP → L3 OGL → L4 Three.js family; pick the **lowest** tier that satisfies all functional requirements.
-5. **Pick one primary recipe** — from the router's minimal high-frequency set; at most one secondary recipe if roles demand it.
-6. **Emit `motion_engine_decision`** — document stack family, stack binding, selected tier, rejected tiers, dependency check, reduced-motion strategy, and mobile strategy before writing animation code.
+5. **Pick one primary recipe** — from the router's minimal high-frequency set; add **at most one** secondary recipe only when roles span **feedback + guidance** and both stay token-light (never atmosphere as secondary).
+6. **Mutate the recipe from DNA** — override default distances, easing, stagger, and timing with Motion DNA + signature motif values. Shipping unchanged recipe defaults is a failure.
+7. **Emit `motion_engine_decision`** — document stack family, stack binding, selected tier, signature motif, rejected tiers, dependency check, reduced-motion strategy, and mobile strategy before writing animation code.
 
 Router non-negotiables (see full matrix in the router doc):
 
@@ -212,4 +213,20 @@ Router non-negotiables (see full matrix in the router doc):
 - **Correct stack binding** — do not put React Motion in Vue SFCs or TresJS in React apps
 - **Simplest sufficient technology** — do not reach for Three.js when L1 can carry the feeling
 - **One decorative motion budget** — no stacked parallax, particles, and 3D on the same hero
-- **No default demo aesthetics** — motion must follow Motion DNA and design tokens, not library boilerplate
+- **No default demo aesthetics** — motion must follow Motion DNA, signature motif, and design tokens — not library boilerplate
+- **Break mediocrity gravity** — correct timing alone is not enough; the signature motif must make the motion feel like *this* product's references and vibe
+
+## Signature motion motif
+
+Every concept direction and every formalized motion system needs **one** signature motif: a short, memorable motion idea derived from the user's references and feeling — not from a library demo.
+
+| Source | How to derive the motif |
+|--------|-------------------------|
+| UI reference | What movement would preserve the reference's *tempo and causality* without cloning its exact animation? |
+| Atmosphere / photo / film | Translate rhythm, weight, and stillness into distance, easing, and stagger — never paste the photo into the hero as motion |
+| Music | Map BPM → tempo, dynamics → distance, syncopation → stagger pattern |
+| Product personality | Reliable → composed settles; playful → elastic micro-overshoot on feedback only; premium → slow large reveals with calm easing |
+
+**Motif test**: If you strip brand colors and fonts, would a stranger still sense the same personality from the motion alone? If not, the motif is too generic (usually "everything fades up 16px").
+
+Record the motif in the design system (e.g. `"cards settle like soft paper, 12px rise, calm ease-out, 60ms stagger"`). Recipes are skeletons; the motif supplies the soul.

--- a/references/MOTION-SYSTEM.md
+++ b/references/MOTION-SYSTEM.md
@@ -192,3 +192,22 @@ Let these factors shape the motion personality — don't map product category to
 ## Output
 
 Generate motion tokens as part of the design system output using the motion section of [../assets/design-system-template.md](../assets/design-system-template.md).
+
+## Motion Engine Router (progressive load)
+
+**During exploration and token extraction**, stop at Motion DNA + motion tokens. Do **not** load implementation libraries yet.
+
+**When implementing motion in code** (standalone preview HTML, concept page, or Apply to project), progressively load [MOTION-ENGINE-ROUTER.md](MOTION-ENGINE-ROUTER.md) and run:
+
+1. **Compile Motion DNA** — finalize the eight dimensions plus narrative (`personality`, `page_metaphor`, `primary_intent`) from vibe, reference, music, and page type.
+2. **Capability check** — list only the expressiveness that is **required** (feedback, scroll narrative, shader atmosphere, true 3D, etc.).
+3. **Select one engine tier** — L1 Motion → L2 GSAP → L3 OGL → L4 Three.js/R3F; pick the **lowest** tier that satisfies all functional requirements.
+4. **Pick one primary recipe** — from the router's minimal high-frequency set; at most one secondary recipe if roles demand it.
+5. **Emit `motion_engine_decision`** — document selected tier, rejected tiers, dependency check, reduced-motion strategy, and mobile strategy before writing animation code.
+
+Router non-negotiables (see full matrix in the router doc):
+
+- **One engine per surface** — never mix Motion + GSAP + WebGL runtimes on the same page
+- **Simplest sufficient technology** — do not reach for Three.js when Motion can carry the feeling
+- **One decorative motion budget** — no stacked parallax, particles, and 3D on the same hero
+- **No default demo aesthetics** — motion must follow Motion DNA and design tokens, not library boilerplate

--- a/references/MOTION-SYSTEM.md
+++ b/references/MOTION-SYSTEM.md
@@ -201,13 +201,15 @@ Generate motion tokens as part of the design system output using the motion sect
 
 1. **Compile Motion DNA** — finalize the eight dimensions plus narrative (`personality`, `page_metaphor`, `primary_intent`) from vibe, reference, music, and page type.
 2. **Capability check** — list only the expressiveness that is **required** (feedback, scroll narrative, shader atmosphere, true 3D, etc.).
-3. **Select one engine tier** — L1 Motion → L2 GSAP → L3 OGL → L4 Three.js/R3F; pick the **lowest** tier that satisfies all functional requirements.
-4. **Pick one primary recipe** — from the router's minimal high-frequency set; at most one secondary recipe if roles demand it.
-5. **Emit `motion_engine_decision`** — document selected tier, rejected tiers, dependency check, reduced-motion strategy, and mobile strategy before writing animation code.
+3. **Detect stack family** — `web` | `react` | `vue` (web-first scope; not RN/Flutter). Bind packages to that family (e.g. L1 → CSS/`motion` | `motion`/`framer-motion` | `motion-v`/`@vueuse/motion`; L4 → `three` | R3F | TresJS).
+4. **Select one engine tier** — L1 → L2 GSAP → L3 OGL → L4 Three.js family; pick the **lowest** tier that satisfies all functional requirements.
+5. **Pick one primary recipe** — from the router's minimal high-frequency set; at most one secondary recipe if roles demand it.
+6. **Emit `motion_engine_decision`** — document stack family, stack binding, selected tier, rejected tiers, dependency check, reduced-motion strategy, and mobile strategy before writing animation code.
 
 Router non-negotiables (see full matrix in the router doc):
 
 - **One engine per surface** — never mix Motion + GSAP + WebGL runtimes on the same page
-- **Simplest sufficient technology** — do not reach for Three.js when Motion can carry the feeling
+- **Correct stack binding** — do not put React Motion in Vue SFCs or TresJS in React apps
+- **Simplest sufficient technology** — do not reach for Three.js when L1 can carry the feeling
 - **One decorative motion budget** — no stacked parallax, particles, and 3D on the same hero
 - **No default demo aesthetics** — motion must follow Motion DNA and design tokens, not library boilerplate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a progressive-load **Motion Engine Router** that turns confirmed Motion DNA into exactly one implementation engine, one **Web / React / Vue** stack binding, and one primary recipe — then **mutates** that recipe with a **signature motion motif** so agents break “correct but mediocre” LLM gravity.

## What's new

- **`references/MOTION-ENGINE-ROUTER.md`**
  - Vibe → Motion DNA + **signature motif**
  - L1–L4 ladder with Web / React / Vue bindings (`motion` / `motion-v` / GSAP / OGL / R3F / TresJS)
  - L1 recipes including **`sheet-rise`** and **`tab-indicator`** for Consumer apps
  - Secondary recipe rule: **feedback + guidance only**
  - Recipe mutation + **Step 10 mediocrity self-review**
  - `motion_engine_decision` with `signature_motif` + `recipe_mutations`

- **`SKILL.md`**
  - Router loads at **preview Step 7 / Apply**, not during analysis
  - **Exploration Interim Motion** (CSS + provisional DNA + motif) for concept previews

- Wired into `MOTION-SYSTEM.md`, `DESIGN-SYSTEM.md`, design-system template, READMEs

## Bugbot follow-ups addressed

1. Router placement moved off analysis into implementation/preview
2. Secondary recipe rules aligned
3. Exploration interim motion rules added
4. Consumer sheet/tab recipes added

## Product bet

Correct engine selection prevents bad motion; **signature motif + recipe mutation + mediocrity gate** is how we aim for distinctive motion from the user’s references and feeling — not generic fade-up kits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32b9303f-706c-40c3-a74d-5f1699bea1c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32b9303f-706c-40c3-a74d-5f1699bea1c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

