### PR TITLE
Pin skills install command to v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Or mix and match — use one reference for structure, another for atmosphere, an
 **Preferred — works with Claude Code, Codex, Cursor, Gemini CLI, Kimi Code, and any `npx`-capable agent:**
 
 ```bash
-npx skills add MonkeyUI-dev/vibe-to-ui
+npx skills add MonkeyUI-dev/vibe-to-ui#v0.3.0
 ```
 
 **Manual (git clone):**

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -145,7 +145,7 @@ vibe-to-ui 是这把翻译工具。把一张照片、一段录音、一种说不
 **推荐方式 —— 适用于 Claude Code、Codex、Cursor、Gemini CLI、Kimi Code 等任何支持 `npx` 的 Agent：**
 
 ```bash
-npx skills add MonkeyUI-dev/vibe-to-ui
+npx skills add MonkeyUI-dev/vibe-to-ui#v0.3.0
 ```
 
 **手动安装（git clone）：**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`npx skills add MonkeyUI-dev/vibe-to-ui` clones the repo **default branch** (`main`), not a GitHub Release. This updates the documented install command in both READMEs to pin the current release tag:

```bash
npx skills add MonkeyUI-dev/vibe-to-ui#v0.3.0
```

## Changes

- `README.md` — pin install command to `#v0.3.0`
- `README.zh_CN.md` — same pin for the Chinese install section

Version matches the latest git tag and `SKILL.md` frontmatter (`0.3.0`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34c65d94-1c05-48f3-9781-f5d73d5d79e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34c65d94-1c05-48f3-9781-f5d73d5d79e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

