### PR TITLE
docs: update install command to v0.4.0 in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can ship systems. You can feel when something looks off. What's missing is a
 ## Install
 
 ```bash
-npx skills add MonkeyUI-dev/vibe-to-ui#v0.3.0
+npx skills add MonkeyUI-dev/vibe-to-ui#v0.4.0
 ```
 
 Works with Claude Code, Cursor, Codex, Gemini CLI, Kimi Code, and any `npx`-capable agent.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -36,7 +36,7 @@
 ## 安装
 
 ```bash
-npx skills add MonkeyUI-dev/vibe-to-ui#v0.3.0
+npx skills add MonkeyUI-dev/vibe-to-ui#v0.4.0
 ```
 
 适用于 Claude Code、Cursor、Codex、Gemini CLI、Kimi Code 等支持 `npx` 的 Agent。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the `npx skills add` install pin from `v0.3.0` to `v0.4.0` in both `README.md` and `README.zh_CN.md` ahead of the v0.4.0 release.

`package.json` already lists version `0.4.0`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dd0b3aa-d450-4448-9752-240fee4cf8f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dd0b3aa-d450-4448-9752-240fee4cf8f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

