### PR TITLE
feat: Design Context Git remote sync MVP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,21 @@ test -f "$HOME/.vibe-to-ui/profiles/demo/targets/print-brochure.md"
 test ! -e "$HOME/.vibe-to-ui/profiles/demo/targets/web.md"  # only requested targets
 ```
 
+5. Remote sync smoke (local bare repo — no GitHub required), when touching `lib/git.js` / `lib/remote.js`:
+
+```bash
+export HOME=/tmp/vibe-to-ui-remote-smoke-a
+rm -rf "$HOME" /tmp/vibe-to-ui-remote.git /tmp/vibe-to-ui-remote-smoke-b
+git init --bare /tmp/vibe-to-ui-remote.git
+node bin/vibe-to-ui.js context --profile vibe-to-ui --init
+node bin/vibe-to-ui.js context remote connect /tmp/vibe-to-ui-remote.git
+node bin/vibe-to-ui.js context sync
+# Computer B restore
+export HOME=/tmp/vibe-to-ui-remote-smoke-b
+node bin/vibe-to-ui.js context remote connect /tmp/vibe-to-ui-remote.git
+test -f "$HOME/.vibe-to-ui/profiles/vibe-to-ui/brand.md"
+```
+
 ### Consuming / demonstrating the skill
 
 The official consumer tooling is the `skills` CLI (already runnable via `npx skills ...`).

--- a/README.md
+++ b/README.md
@@ -120,9 +120,11 @@ Keep a brand profile on your machine — outside the skill — so reinstall neve
 node bin/vibe-to-ui.js context --list
 node bin/vibe-to-ui.js context --profile my-brand --init
 node bin/vibe-to-ui.js context --profile my-brand --target web
+node bin/vibe-to-ui.js context remote connect git@github.com:org/design-contexts.git
+node bin/vibe-to-ui.js context sync
 ```
 
-Root: `~/.vibe-to-ui` (fixed; no env override). Medium targets are open-ended (`web`, `linkedin`, `print-brochure`, …) — not a fixed enum.
+Root: `~/.vibe-to-ui` (fixed; no env override). Medium targets are open-ended (`web`, `linkedin`, `print-brochure`, …) — not a fixed enum. Optional Git remote sync shares the same root via your private repo.
 
 Details: [DESIGN-CONTEXT.md](references/DESIGN-CONTEXT.md)
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -120,9 +120,11 @@ git clone https://github.com/MonkeyUI-dev/vibe-to-ui.git ~/.agents/skills/vibe-t
 node bin/vibe-to-ui.js context --list
 node bin/vibe-to-ui.js context --profile my-brand --init
 node bin/vibe-to-ui.js context --profile my-brand --target web
+node bin/vibe-to-ui.js context remote connect git@github.com:org/design-contexts.git
+node bin/vibe-to-ui.js context sync
 ```
 
-根目录：`~/.vibe-to-ui`（固定路径，无环境变量覆盖）。媒介 Target 开放自定义（`web`、`linkedin`、`print-brochure`…），不是封闭枚举。
+根目录：`~/.vibe-to-ui`（固定路径，无环境变量覆盖）。媒介 Target 开放自定义（`web`、`linkedin`、`print-brochure`…），不是封闭枚举。可选 Git remote sync 通过你的私有仓库跨设备/团队共享同一根目录。
 
 详见：[DESIGN-CONTEXT.md](references/DESIGN-CONTEXT.md)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,8 +6,9 @@ description: >-
   music, or fuzzy aesthetic intent. Classifies page archetype, explores 3
   product-aware directions before locking tokens (unless exact restoration),
   and applies only after confirmation. Use when designing or restyling UI,
-  exploring visual direction, extracting tokens/motion, generating assets, or
-  saving brand context under ~/.vibe-to-ui for multi-medium handoff.
+  exploring visual direction, extracting tokens/motion, generating assets,
+  saving brand context under ~/.vibe-to-ui, or Git remote sync of Design Context
+  for cross-device and team sharing.
 metadata:
   author: MonkeyUI
   version: "0.4.0"
@@ -17,7 +18,7 @@ metadata:
 
 A local design companion for vibe coding developers. It first classifies the target page archetype and density, then uses the user's product background to derive three plausible visual and spatial directions from references before formalizing any one of them into a design system. It extracts "style DNA" including motion systems, Consumer app UIUX needs, visual asset direction, mood boards, and previews, and turns vague aesthetic feelings into product-aware design decisions that actually fit the product surface. Inspiration may be a **website URL**, screenshot, images, music, or fuzzy intent — the agent adapts to what the user provides (see [references/INSPIRATION-SOURCES.md](references/INSPIRATION-SOURCES.md)). It can also persist a reusable **Design Context** profile under `~/.vibe-to-ui/profiles/<profile>/` (brand master, tokens, decisions, assets) and adapt it on demand into **open-ended medium targets** — examples include `web`, `social-cover`, and `hyperframes`, and users may define their own (e.g. `linkedin`, `print-brochure`) — without coupling user data to skill install/update. All exploration happens through standalone previews; the agent only touches the user's project when the user confirms a direction and asks to apply it.
 
-> **Tip**: For multi-project sync, team collaboration, and cloud-based design management, upgrade to [MonkeyUI SaaS](https://demo.monkeyui.com/).
+> **Tip**: Git-based Design Context remote sync (`context remote` / `context sync`) shares `~/.vibe-to-ui` via your own private repo. For hosted multi-project management beyond Git, see [MonkeyUI SaaS](https://demo.monkeyui.com/).
 
 ## When to use this skill
 
@@ -150,7 +151,7 @@ When the user wants reusable brand memory across projects or media, use **Capabi
 - A **profile** is a brand, product, or client (e.g. `vibe-to-ui`, `acme-brand`) — not an output platform.
 - Live data lives only under `~/.vibe-to-ui/profiles/<profile>/`. Skill templates under `assets/design-context/` are seeds to copy, never the live store.
 - **Skill install, update, or reinstall must never overwrite, delete, or reset `~/.vibe-to-ui/`.**
-- Prefer the Node CLI (`bin/vibe-to-ui.js`) for `--list` / `--init` / `--target` lifecycle and merge assembly.
+- Prefer the Node CLI (`bin/vibe-to-ui.js`) for `--list` / `--init` / `--target` lifecycle, merge assembly, and optional Git remote sync (`remote connect` / `remote status` / `sync`).
 - `targets/<medium>.md` files are created on first request for that medium (open-ended ids; `web` / `social-cover` / `hyperframes` are examples only), then reused and updated.
 - Prefer an active profile's `brand.md` + `tokens.json` for brand fidelity; keep project `DESIGN.md` for product/page-local context.
 
@@ -366,6 +367,9 @@ User wants reusable brand visual language extracted from a website URL or screen
 vibe-to-ui context --list
 vibe-to-ui context --profile <profile> --init
 vibe-to-ui context --profile <profile> --target <medium>
+vibe-to-ui context remote connect <git-url>
+vibe-to-ui context remote status
+vibe-to-ui context sync
 ```
 
 `<medium>` is any kebab-case medium id. Examples (not an allow-list): `web`, `social-cover`, `hyperframes`, `linkedin`, `print-brochure`.
@@ -376,9 +380,10 @@ Run as `node <skill>/bin/vibe-to-ui.js ...` or `npx vibe-to-ui ...` when the pac
 1. Resolve a kebab-case **profile** id (brand / product / client — not a medium). Prefer `vibe-to-ui context --profile <id> --init` to create the skeleton (shared seeds only; no `targets/` yet).
 2. Brand extraction (URL/screenshot/images) remains agent-led for now — write into the initialized profile's `brand.md` / `tokens.json` / `decisions.md` / `sources/`.
 3. On `--target <name>`: run the CLI so it creates or reuses `targets/<name>.md` and prints the merged handoff package. Fill stub target content from the brand master using the guides in [references/DESIGN-CONTEXT.md](references/DESIGN-CONTEXT.md). Do not reject user-defined media.
-4. When working inside a project, also read project `DESIGN.md` if present; optionally record `design_context_profile: <profile>` in Iteration Context. Do not replace `DESIGN.md` with the profile.
+4. Optional team/cross-device share: `remote connect` to a private Git repo, then `sync` (validates `tokens.json`, commits, rebase-pulls, pushes; aborts on conflict without overwriting). Use `remote status` to inspect ahead/behind.
+5. When working inside a project, also read project `DESIGN.md` if present; optionally record `design_context_profile: <profile>` in Iteration Context. Do not replace `DESIGN.md` with the profile.
 
-**Non-negotiable**: User data under `~/.vibe-to-ui/` is outside the skill lifecycle. Skill update or reinstall must never overwrite it. This MVP does not implement cloud sync, team collaboration, or vector search.
+**Non-negotiable**: User data under `~/.vibe-to-ui/` is outside the skill lifecycle. Skill update or reinstall must never overwrite it. Remote sync reuses the user's Git credentials only — no OAuth, auto-merge, or cloud account in this MVP.
 
 ## Combining capabilities
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -387,6 +387,9 @@ Usage:
   vibe-to-ui context --list
   vibe-to-ui context --profile <id> --init
   vibe-to-ui context --profile <id> --target <medium>
+  vibe-to-ui context remote connect <git-url>
+  vibe-to-ui context remote status
+  vibe-to-ui context sync
 
 Options:
   --list                 List profiles under ~/.vibe-to-ui (read-only)
@@ -395,10 +398,16 @@ Options:
   --target <medium>      Ensure targets/<medium>.md exists; print merged context
   -h, --help             Show help
 
+Remote sync:
+  remote connect <url>   Bind ~/.vibe-to-ui to a private Git repo (no auto-upload)
+  remote status          Show remote URL, branch, local changes, ahead/behind
+  sync                   Validate, commit, rebase, push (abort on conflict)
+
 Notes:
   - Design Context root is always ~/.vibe-to-ui (no env override).
   - User data lives outside the skill package; skill reinstall must not touch it.
   - Targets are open-ended medium ids — no built-in GitHub/LinkedIn packs.
+  - Remote sync reuses your existing Git SSH/HTTPS credentials.
   - --from-url / --from-image are not implemented in this CLI yet (agent workflow).
 `);
 }
@@ -412,7 +421,52 @@ function parseArgs(argv) {
     throw new Error(`Unknown command "${args[0]}". Only "context" is supported in this MVP.`);
   }
 
-  const opts = { help: false, list: false, init: false, profile: null, target: null };
+  const opts = {
+    help: false,
+    list: false,
+    init: false,
+    profile: null,
+    target: null,
+    remoteConnect: null,
+    remoteStatus: false,
+    sync: false,
+  };
+
+  // Nested subcommands: remote connect|status, sync
+  if (args[1] === 'remote') {
+    const sub = args[2];
+    if (sub === 'connect') {
+      opts.remoteConnect = args[3];
+      if (!opts.remoteConnect) {
+        throw new Error('Missing git URL. Usage: vibe-to-ui context remote connect <git-url>');
+      }
+      if (args.length > 4) {
+        throw new Error(`Unexpected argument: ${args[4]}`);
+      }
+      return opts;
+    }
+    if (sub === 'status') {
+      if (args.length > 3) {
+        throw new Error(`Unexpected argument: ${args[3]}`);
+      }
+      opts.remoteStatus = true;
+      return opts;
+    }
+    if (sub === '-h' || sub === '--help' || sub == null) {
+      opts.help = true;
+      return opts;
+    }
+    throw new Error(`Unknown remote subcommand "${sub}". Use: connect | status`);
+  }
+
+  if (args[1] === 'sync') {
+    if (args.length > 2) {
+      throw new Error(`Unexpected argument: ${args[2]}`);
+    }
+    opts.sync = true;
+    return opts;
+  }
+
   for (let i = 1; i < args.length; i++) {
     const a = args[i];
     if (a === '-h' || a === '--help') opts.help = true;
@@ -439,6 +493,32 @@ function main(argv = process.argv) {
       return;
     }
     const root = resolveHomeRoot();
+    const remote = require('./remote');
+
+    if (opts.remoteConnect != null) {
+      if (opts.list || opts.init || opts.target || opts.profile || opts.remoteStatus || opts.sync) {
+        throw new Error('remote connect cannot be combined with other context commands');
+      }
+      assertWritableDir(root);
+      remote.cmdRemoteConnect(root, opts.remoteConnect);
+      return;
+    }
+
+    if (opts.remoteStatus) {
+      if (opts.list || opts.init || opts.target || opts.profile || opts.sync) {
+        throw new Error('remote status cannot be combined with other context commands');
+      }
+      remote.cmdRemoteStatus(root);
+      return;
+    }
+
+    if (opts.sync) {
+      if (opts.list || opts.init || opts.target || opts.profile) {
+        throw new Error('sync cannot be combined with other context commands');
+      }
+      remote.cmdSync(root);
+      return;
+    }
 
     if (opts.list) {
       if (opts.init || opts.target || opts.profile) {
@@ -461,7 +541,9 @@ function main(argv = process.argv) {
       return;
     }
 
-    throw new Error('Nothing to do. Use --list, --init, or --target. See --help.');
+    throw new Error(
+      'Nothing to do. Use --list, --init, --target, remote connect|status, or sync. See --help.'
+    );
   } catch (err) {
     console.error(`error: ${err.message}`);
     process.exitCode = 1;

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,0 +1,259 @@
+'use strict';
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_BRANCH = 'main';
+const REMOTE_NAME = 'origin';
+
+const GITIGNORE_CONTENT = `# vibe-to-ui Design Context — do not sync secrets
+.env
+.env.*
+*.pem
+*.key
+*credentials*
+id_rsa
+id_rsa.*
+id_ed25519
+id_ed25519.*
+.DS_Store
+.write-check-*
+`;
+
+function runGit(cwd, args, options = {}) {
+  const { allowFailure = false, input } = options;
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    input: input != null ? input : undefined,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+
+  if (result.error) {
+    if (result.error.code === 'ENOENT') {
+      throw new Error(
+        'git is required for Design Context remote sync but was not found on PATH. Install Git and retry.'
+      );
+    }
+    throw new Error(`git ${args.join(' ')} failed: ${result.error.message}`);
+  }
+
+  const stdout = (result.stdout || '').trim();
+  const stderr = (result.stderr || '').trim();
+
+  if (result.status !== 0 && !allowFailure) {
+    const detail = stderr || stdout || `exit ${result.status}`;
+    const err = new Error(`git ${args.join(' ')} failed: ${detail}`);
+    err.status = result.status;
+    err.stdout = stdout;
+    err.stderr = stderr;
+    throw err;
+  }
+
+  return { status: result.status, stdout, stderr };
+}
+
+function isRepo(cwd) {
+  const r = runGit(cwd, ['rev-parse', '--is-inside-work-tree'], { allowFailure: true });
+  return r.status === 0 && r.stdout === 'true';
+}
+
+function ensureRepo(cwd) {
+  if (isRepo(cwd)) return false;
+  runGit(cwd, ['init']);
+  // Prefer main as the default branch for new repos.
+  const branch = currentBranch(cwd);
+  if (branch && branch !== DEFAULT_BRANCH) {
+    runGit(cwd, ['branch', '-M', DEFAULT_BRANCH], { allowFailure: true });
+  } else if (!branch) {
+    runGit(cwd, ['checkout', '-b', DEFAULT_BRANCH], { allowFailure: true });
+  }
+  return true;
+}
+
+function ensureGitignore(cwd) {
+  const ignorePath = path.join(cwd, '.gitignore');
+  if (fs.existsSync(ignorePath)) return false;
+  fs.writeFileSync(ignorePath, GITIGNORE_CONTENT, 'utf8');
+  return true;
+}
+
+function getRemoteUrl(cwd, name = REMOTE_NAME) {
+  const r = runGit(cwd, ['remote', 'get-url', name], { allowFailure: true });
+  if (r.status !== 0) return null;
+  return r.stdout || null;
+}
+
+function addOrVerifyRemote(cwd, url, name = REMOTE_NAME) {
+  const existing = getRemoteUrl(cwd, name);
+  if (!existing) {
+    runGit(cwd, ['remote', 'add', name, url]);
+    return 'added';
+  }
+  if (normalizeRemoteUrl(existing) !== normalizeRemoteUrl(url)) {
+    throw new Error(
+      `Remote "${name}" is already set to ${existing}\n` +
+        `Refusing to replace it with ${url}.\n` +
+        `Remove or update the remote manually if you intend to switch repositories.`
+    );
+  }
+  return 'unchanged';
+}
+
+function normalizeRemoteUrl(url) {
+  return String(url || '')
+    .trim()
+    .replace(/\.git$/i, '')
+    .replace(/\/$/, '');
+}
+
+function fetchOrigin(cwd) {
+  return runGit(cwd, ['fetch', REMOTE_NAME], { allowFailure: true });
+}
+
+function remoteBranchExists(cwd, branch = DEFAULT_BRANCH) {
+  const ref = `refs/remotes/${REMOTE_NAME}/${branch}`;
+  const r = runGit(cwd, ['show-ref', '--verify', '--quiet', ref], { allowFailure: true });
+  return r.status === 0;
+}
+
+function currentBranch(cwd) {
+  const r = runGit(cwd, ['branch', '--show-current'], { allowFailure: true });
+  if (r.status !== 0) return null;
+  return r.stdout || null;
+}
+
+function hasLocalCommits(cwd) {
+  const r = runGit(cwd, ['rev-parse', '--verify', 'HEAD'], { allowFailure: true });
+  return r.status === 0;
+}
+
+function porcelainStatus(cwd) {
+  const r = runGit(cwd, ['status', '--porcelain'], { allowFailure: true });
+  if (r.status !== 0) return [];
+  if (!r.stdout) return [];
+  return r.stdout.split('\n').filter(Boolean).map((line) => {
+    // XY PATH or XY ORIG -> PATH for renames
+    const pathPart = line.slice(3);
+    const arrow = pathPart.indexOf(' -> ');
+    const filePath = arrow >= 0 ? pathPart.slice(arrow + 4) : pathPart;
+    return { raw: line, path: filePath };
+  });
+}
+
+function aheadBehind(cwd, branch = DEFAULT_BRANCH) {
+  if (!remoteBranchExists(cwd, branch)) {
+    return { ahead: null, behind: null, upstream: null };
+  }
+  const upstream = `${REMOTE_NAME}/${branch}`;
+  if (!hasLocalCommits(cwd)) {
+    return { ahead: 0, behind: null, upstream };
+  }
+  const r = runGit(cwd, ['rev-list', '--left-right', '--count', `HEAD...${upstream}`], {
+    allowFailure: true,
+  });
+  if (r.status !== 0 || !r.stdout) {
+    return { ahead: null, behind: null, upstream };
+  }
+  const [left, right] = r.stdout.split(/\s+/).map((n) => Number(n));
+  return {
+    ahead: Number.isFinite(left) ? left : null,
+    behind: Number.isFinite(right) ? right : null,
+    upstream,
+  };
+}
+
+function isRebaseInProgress(cwd) {
+  const gitDir = runGit(cwd, ['rev-parse', '--git-dir'], { allowFailure: true });
+  if (gitDir.status !== 0) return false;
+  const dir = path.resolve(cwd, gitDir.stdout);
+  return (
+    fs.existsSync(path.join(dir, 'rebase-merge')) ||
+    fs.existsSync(path.join(dir, 'rebase-apply'))
+  );
+}
+
+function unmergedPaths(cwd) {
+  const r = runGit(cwd, ['diff', '--name-only', '--diff-filter=U'], { allowFailure: true });
+  if (r.status !== 0 || !r.stdout) return [];
+  return r.stdout.split('\n').filter(Boolean);
+}
+
+function checkoutRemoteMain(cwd, branch = DEFAULT_BRANCH) {
+  // Restore remote content into an empty local tree without pushing.
+  runGit(cwd, ['checkout', '-B', branch, `${REMOTE_NAME}/${branch}`]);
+}
+
+function stageSafePaths(cwd) {
+  const profiles = path.join(cwd, 'profiles');
+  const ignore = path.join(cwd, '.gitignore');
+  const args = ['add', '-A', '--'];
+  if (fs.existsSync(profiles)) args.push('profiles');
+  if (fs.existsSync(ignore)) args.push('.gitignore');
+  if (args.length === 3) return; // nothing to add
+  runGit(cwd, args);
+}
+
+function hasStagedChanges(cwd) {
+  const r = runGit(cwd, ['diff', '--cached', '--quiet'], { allowFailure: true });
+  // exit 1 means differences exist
+  return r.status === 1;
+}
+
+function ensureCommitIdentity(cwd) {
+  const name = runGit(cwd, ['config', '--get', 'user.name'], { allowFailure: true });
+  const email = runGit(cwd, ['config', '--get', 'user.email'], { allowFailure: true });
+  // Local-only fallback so sync works in fresh environments without global git config.
+  if (name.status !== 0 || !name.stdout) {
+    runGit(cwd, ['config', 'user.name', 'vibe-to-ui']);
+  }
+  if (email.status !== 0 || !email.stdout) {
+    runGit(cwd, ['config', 'user.email', 'vibe-to-ui@localhost']);
+  }
+}
+
+function commitStaged(cwd, message) {
+  ensureCommitIdentity(cwd);
+  runGit(cwd, ['commit', '-m', message]);
+}
+
+function pullRebase(cwd, branch = DEFAULT_BRANCH) {
+  return runGit(cwd, ['pull', '--rebase', REMOTE_NAME, branch], { allowFailure: true });
+}
+
+function rebaseAbort(cwd) {
+  runGit(cwd, ['rebase', '--abort'], { allowFailure: true });
+}
+
+function pushOrigin(cwd, branch = DEFAULT_BRANCH) {
+  runGit(cwd, ['push', '-u', REMOTE_NAME, branch]);
+}
+
+module.exports = {
+  DEFAULT_BRANCH,
+  REMOTE_NAME,
+  GITIGNORE_CONTENT,
+  runGit,
+  isRepo,
+  ensureRepo,
+  ensureGitignore,
+  getRemoteUrl,
+  addOrVerifyRemote,
+  normalizeRemoteUrl,
+  fetchOrigin,
+  remoteBranchExists,
+  currentBranch,
+  hasLocalCommits,
+  porcelainStatus,
+  aheadBehind,
+  isRebaseInProgress,
+  unmergedPaths,
+  checkoutRemoteMain,
+  stageSafePaths,
+  hasStagedChanges,
+  commitStaged,
+  pullRebase,
+  rebaseAbort,
+  pushOrigin,
+};

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -1,0 +1,298 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const git = require('./git');
+
+const SYNC_COMMIT_MESSAGE = 'chore: sync design context';
+
+function profilesDir(root) {
+  return path.join(root, 'profiles');
+}
+
+function listProfileIds(root) {
+  const dir = profilesDir(root);
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+    .map((d) => d.name)
+    .sort();
+}
+
+function hasLocalProfileContent(root) {
+  const dir = profilesDir(root);
+  if (!fs.existsSync(dir)) return false;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.some((e) => !e.name.startsWith('.'));
+}
+
+function validateTokensJson(root) {
+  const ids = listProfileIds(root);
+  const errors = [];
+  for (const id of ids) {
+    const tokensPath = path.join(profilesDir(root), id, 'tokens.json');
+    if (!fs.existsSync(tokensPath)) continue;
+    const raw = fs.readFileSync(tokensPath, 'utf8');
+    try {
+      JSON.parse(raw);
+    } catch (err) {
+      errors.push(`profiles/${id}/tokens.json: ${err.message}`);
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(
+      `Invalid tokens.json — sync aborted before commit.\n` + errors.map((e) => `  - ${e}`).join('\n')
+    );
+  }
+}
+
+function requireRepoWithOrigin(root) {
+  if (!git.isRepo(root)) {
+    throw new Error(
+      `No Git repository at ${root}.\n` +
+        `Run: vibe-to-ui context remote connect <git-url>`
+    );
+  }
+  const url = git.getRemoteUrl(root);
+  if (!url) {
+    throw new Error(
+      `No origin remote configured under ${root}.\n` +
+        `Run: vibe-to-ui context remote connect <git-url>`
+    );
+  }
+  return url;
+}
+
+/**
+ * Bind ~/.vibe-to-ui to a private Git remote. Never overwrites local profiles
+ * or pushes unknown local data.
+ */
+function cmdRemoteConnect(root, gitUrl) {
+  if (!gitUrl || String(gitUrl).trim() === '') {
+    throw new Error('Missing git URL. Usage: vibe-to-ui context remote connect <git-url>');
+  }
+  const url = String(gitUrl).trim();
+
+  // Caller must ensure root exists and is writable (Computer B restore path).
+  const createdRepo = git.ensureRepo(root);
+  const remoteAction = git.addOrVerifyRemote(root, url);
+
+  console.log(`Design Context root: ${root}`);
+  if (createdRepo) console.log('Initialized Git repository (branch: main).');
+  if (remoteAction === 'added') console.log(`Added origin: ${url}`);
+  else console.log(`Origin already set: ${url}`);
+
+  const fetch = git.fetchOrigin(root);
+  if (fetch.status !== 0) {
+    const detail = fetch.stderr || fetch.stdout || `exit ${fetch.status}`;
+    throw new Error(
+      `Connected origin but fetch failed: ${detail}\n` +
+        `Check SSH/HTTPS credentials and that the remote is reachable.`
+    );
+  }
+  console.log('Fetched origin.');
+
+  const localContent = hasLocalProfileContent(root);
+  const remoteHasMain = git.remoteBranchExists(root, git.DEFAULT_BRANCH);
+
+  if (!localContent && remoteHasMain) {
+    // Drop an untracked seed .gitignore so checkout can restore the remote copy.
+    const ignorePath = path.join(root, '.gitignore');
+    if (fs.existsSync(ignorePath)) {
+      const tracked = git.runGit(root, ['ls-files', '--error-unmatch', '.gitignore'], {
+        allowFailure: true,
+      });
+      if (tracked.status !== 0) fs.unlinkSync(ignorePath);
+    }
+    git.checkoutRemoteMain(root, git.DEFAULT_BRANCH);
+    const createdIgnore = git.ensureGitignore(root);
+    if (createdIgnore) console.log('Created .gitignore (secrets excluded).');
+    const ids = listProfileIds(root);
+    console.log('Local profiles were empty — restored from remote.');
+    if (ids.length > 0) {
+      console.log(`Profiles: ${ids.join(', ')}`);
+    } else {
+      console.log('Remote main has no profiles yet.');
+    }
+    console.log('Status: Connected');
+    return;
+  }
+
+  const createdIgnore = git.ensureGitignore(root);
+  if (createdIgnore) console.log('Created .gitignore (secrets excluded).');
+
+  if (localContent && !remoteHasMain) {
+    console.log('Local profiles present; remote has no main branch yet.');
+    console.log('Nothing was uploaded. Run: vibe-to-ui context sync');
+    console.log('Status: Connected (awaiting first sync)');
+    return;
+  }
+
+  if (localContent && remoteHasMain) {
+    console.log('Local profiles and remote main both exist.');
+    console.log('Nothing was overwritten or uploaded.');
+    console.log('Next: vibe-to-ui context remote status');
+    console.log('Then: vibe-to-ui context sync');
+    console.log('Status: Connected');
+    return;
+  }
+
+  // empty + empty
+  console.log('Remote is empty and no local profiles yet.');
+  console.log('Create a profile with --init, then run: vibe-to-ui context sync');
+  console.log('Status: Connected');
+}
+
+function formatAheadBehind({ ahead, behind }) {
+  if (ahead == null && behind == null) return 'No upstream (remote main not fetched yet)';
+  if (behind == null) return 'Remote main present; local history not compared';
+  const parts = [];
+  if (behind > 0) parts.push(`Behind ${behind} commit${behind === 1 ? '' : 's'}`);
+  if (ahead > 0) parts.push(`Ahead ${ahead} commit${ahead === 1 ? '' : 's'}`);
+  if (parts.length === 0) return 'In sync with origin/main';
+  return parts.join(', ');
+}
+
+function cmdRemoteStatus(root) {
+  const url = requireRepoWithOrigin(root);
+
+  // Best-effort fetch for fresh ahead/behind; status still prints if offline.
+  const fetch = git.fetchOrigin(root);
+  const fetchOk = fetch.status === 0;
+
+  const branch = git.currentBranch(root) || '(unknown)';
+  const changes = git.porcelainStatus(root);
+  const ab = git.aheadBehind(root, git.DEFAULT_BRANCH);
+  const rebase = git.isRebaseInProgress(root);
+  const conflicts = rebase ? git.unmergedPaths(root) : [];
+
+  console.log('Design Context Remote');
+  console.log('');
+  console.log('Remote:');
+  console.log(url);
+  console.log('');
+  console.log('Branch:');
+  console.log(branch);
+  console.log('');
+  console.log('Local changes:');
+  if (changes.length === 0) {
+    console.log('(none)');
+  } else {
+    for (const c of changes) {
+      console.log(`- ${c.path}`);
+    }
+  }
+  console.log('');
+  console.log('Remote:');
+  if (!fetchOk) {
+    console.log(`Fetch failed (${fetch.stderr || fetch.stdout || 'offline'}); counts may be stale.`);
+  }
+  console.log(formatAheadBehind(ab));
+  console.log('');
+
+  let statusLine = 'Up to date';
+  if (rebase || conflicts.length > 0) {
+    statusLine = 'Conflict detected';
+  } else if (changes.length > 0 || (ab.behind != null && ab.behind > 0) || (ab.ahead != null && ab.ahead > 0)) {
+    statusLine = 'Sync required';
+  } else if (!git.remoteBranchExists(root) && (changes.length > 0 || hasLocalProfileContent(root))) {
+    statusLine = 'Sync required';
+  }
+
+  console.log('Status:');
+  console.log(statusLine);
+
+  if (conflicts.length > 0) {
+    console.log('');
+    console.log('Conflicted files:');
+    for (const p of conflicts) console.log(`- ${p}`);
+  }
+}
+
+function printConflictAndAbort(root, paths) {
+  console.error('Conflict detected:');
+  for (const p of paths) {
+    console.error(p);
+  }
+  console.error('');
+  console.error('No files were overwritten.');
+  git.rebaseAbort(root);
+}
+
+function cmdSync(root) {
+  requireRepoWithOrigin(root);
+  git.ensureGitignore(root);
+
+  validateTokensJson(root);
+
+  const fetch = git.fetchOrigin(root);
+  if (fetch.status !== 0) {
+    const detail = fetch.stderr || fetch.stdout || `exit ${fetch.status}`;
+    throw new Error(`git fetch origin failed: ${detail}`);
+  }
+
+  if (git.isRebaseInProgress(root)) {
+    const paths = git.unmergedPaths(root);
+    printConflictAndAbort(root, paths.length > 0 ? paths : ['(rebase in progress)']);
+    process.exitCode = 1;
+    return;
+  }
+
+  git.stageSafePaths(root);
+  if (git.hasStagedChanges(root)) {
+    git.commitStaged(root, SYNC_COMMIT_MESSAGE);
+    console.log(`Committed local changes: ${SYNC_COMMIT_MESSAGE}`);
+  } else {
+    console.log('No local Design Context changes to commit.');
+  }
+
+  const remoteHasMain = git.remoteBranchExists(root, git.DEFAULT_BRANCH);
+  if (remoteHasMain && git.hasLocalCommits(root)) {
+    const pull = git.pullRebase(root, git.DEFAULT_BRANCH);
+    if (pull.status !== 0) {
+      const conflicted = git.unmergedPaths(root);
+      // Also parse "CONFLICT" paths from stderr if diff-filter is empty mid-abort.
+      let paths = conflicted;
+      if (paths.length === 0) {
+        const fromErr = (pull.stderr || '')
+          .split('\n')
+          .map((line) => {
+            const m = line.match(/CONFLICT(?:\s+\([^)]+\))?:\s+(?:Merge conflict in|.*?in)\s+(.+)$/i);
+            return m ? m[1].trim() : null;
+          })
+          .filter(Boolean);
+        paths = fromErr;
+      }
+      if (paths.length === 0 && /conflict/i.test(pull.stderr || pull.stdout || '')) {
+        paths = ['(see git status)'];
+      }
+      if (paths.length > 0 || /conflict/i.test(pull.stderr || '') || git.isRebaseInProgress(root)) {
+        printConflictAndAbort(root, paths.length > 0 ? paths : ['(unresolved rebase)']);
+        process.exitCode = 1;
+        return;
+      }
+      throw new Error(`git pull --rebase failed: ${pull.stderr || pull.stdout || `exit ${pull.status}`}`);
+    }
+    console.log('Rebased onto origin/main.');
+  }
+
+  if (!git.hasLocalCommits(root)) {
+    console.log('Nothing to push (no commits yet).');
+    return;
+  }
+
+  git.pushOrigin(root, git.DEFAULT_BRANCH);
+  console.log('Pushed to origin/main.');
+  console.log('Status: Synced');
+}
+
+module.exports = {
+  cmdRemoteConnect,
+  cmdRemoteStatus,
+  cmdSync,
+  validateTokensJson,
+  hasLocalProfileContent,
+  SYNC_COMMIT_MESSAGE,
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-to-ui",
   "version": "0.4.0",
-  "description": "Local Design Context CLI for vibe-to-ui — profile init, list, and medium target merge",
+  "description": "Design Context CLI for vibe-to-ui — profile init, list, target merge, and Git remote sync",
   "bin": {
     "vibe-to-ui": "./bin/vibe-to-ui.js"
   },

--- a/references/DESIGN-CONTEXT.md
+++ b/references/DESIGN-CONTEXT.md
@@ -8,7 +8,7 @@ It turns a website URL or screenshot into a reusable brand visual language, pers
 
 This is the 90/10 MVP: reuse existing extraction capabilities (Design System Extraction, Aesthetic Analysis, Motion System), write plain files, and keep user data separate from skill install/update. When the user provides a URL, intake follows [INSPIRATION-SOURCES.md](INSPIRATION-SOURCES.md) (browse → frontend cues → selective capture → optional motion); screenshots and other sources remain equally valid.
 
-**Out of scope for this MVP:** cloud sync, team collaboration, vector databases, and complex UI.
+Optional **Git remote sync** binds `~/.vibe-to-ui` to a private repository the user already controls (SSH/HTTPS credentials). **Out of scope:** OAuth/account systems, Web UI, cloud databases, S3, Git LFS, realtime collaboration, auto-merge, and vector search.
 
 ## Core vocabulary
 
@@ -61,6 +61,9 @@ Expand `~` to the current user's home directory. If `$HOME` / `~` is unavailable
 vibe-to-ui context --list
 vibe-to-ui context --profile <profile> --init
 vibe-to-ui context --profile <profile> --target <medium>
+vibe-to-ui context remote connect <git-url>
+vibe-to-ui context remote status
+vibe-to-ui context sync
 ```
 
 `<medium>` is a kebab-case medium id. Examples (not an exhaustive allow-list): `web`, `social-cover`, `hyperframes`, `linkedin`, `print-brochure`, `email-header`.
@@ -74,10 +77,13 @@ This skill package ships a **Node.js zero-dependency CLI** (`bin/vibe-to-ui.js`,
 | `--list` | **Read-only** list of profiles under `~/.vibe-to-ui`. If the root does not exist, print an empty-state message — never create directories. |
 | `--profile <id> --init` | Create profile skeleton from `assets/design-context/` seeds; create `assets/` + `sources/`; **do not** create `targets/`; never overwrite existing shared files |
 | `--profile <id> --target <medium>` | Ensure `targets/<medium>.md` exists (create stub if missing, else reuse); append a decision note **only on first create**; print **merged context** on stdout |
+| `remote connect <git-url>` | Init Git in `~/.vibe-to-ui` if needed, add `origin`, fetch. Restore remote profiles **only when local profiles are empty**. Never auto-upload or overwrite local profiles. |
+| `remote status` | Show remote URL, branch, local changes, ahead/behind, conflict/sync summary |
+| `sync` | Validate `tokens.json`, commit safe paths (`profiles/`, `.gitignore`), `pull --rebase`, push `main`. On conflict: abort rebase, print conflicted paths, overwrite nothing. |
 
 Root is always `~/.vibe-to-ui` (`os.homedir()` + `.vibe-to-ui`). There is **no** `VIBE_TO_UI_HOME` override. Do not store profiles under `/tmp` or inside the project/skill directory.
 
-For `--init` / `--target`, the CLI checks that `~/.vibe-to-ui` is writable (user-level home permissions — not elevated privileges). Permission failures exit non-zero with an explicit grant-write message — never fall back to a temp directory.
+For `--init` / `--target` / `remote connect`, the CLI checks that `~/.vibe-to-ui` is writable (user-level home permissions — not elevated privileges). Permission failures exit non-zero with an explicit grant-write message — never fall back to a temp directory.
 
 Run via:
 
@@ -86,6 +92,9 @@ Run via:
 node bin/vibe-to-ui.js context --list
 node bin/vibe-to-ui.js context --profile vibe-to-ui --init
 node bin/vibe-to-ui.js context --profile vibe-to-ui --target print-brochure
+node bin/vibe-to-ui.js context remote connect git@github.com:org/design-contexts.git
+node bin/vibe-to-ui.js context remote status
+node bin/vibe-to-ui.js context sync
 
 # when the package bin is on PATH (local npm link / npx)
 npx vibe-to-ui context --list
@@ -93,7 +102,29 @@ npx vibe-to-ui context --list
 
 `--from-url` / `--from-image` are **not** implemented in the CLI yet. URL/image extraction remains an agent workflow that writes into an already-initialized profile.
 
-Agents should prefer the CLI for list / init / target lifecycle and merge assembly, then fill brand/target **content** using the skill guides. Agents must **not** invent an alternate storage root.
+Agents should prefer the CLI for list / init / target / remote lifecycle and merge assembly, then fill brand/target **content** using the skill guides. Agents must **not** invent an alternate storage root.
+
+### Remote sync (Git)
+
+The Git repository root is `~/.vibe-to-ui` itself. Tracked layout:
+
+```text
+~/.vibe-to-ui/          # git root + origin
+├── .gitignore          # seeded once; excludes secrets
+└── profiles/
+    └── <profile>/
+        ├── profile.md
+        ├── brand.md
+        ├── tokens.json
+        └── …
+```
+
+Safety rules:
+
+1. **Conflict protection** — same file changed locally and remotely → sync stops; `git rebase --abort`; no overwrite.
+2. **JSON validation** — every `profiles/*/tokens.json` must parse before commit.
+3. **Secrets stay local** — `.env`, keys, and credentials patterns are gitignored; sync stages only `profiles/` and `.gitignore`.
+4. **Connect never pushes** and never overwrites existing local profile content.
 
 ## Profile vs target
 
@@ -298,8 +329,10 @@ Rules:
 - Regenerating an existing target from scratch when a light update would do
 - Treating media ids (`web`, `social-cover`, `hyperframes`, `linkedin`, …) as separate **profiles**
 - Rejecting a user-defined medium because it is not in the example list
-- Cloud sync, team sharing, or embedding pipelines in this MVP
+- Auto-merging or force-pushing on Design Context sync conflicts
+- Uploading `.env`, credentials, or private keys via sync
 - Overwriting `decisions.md` or deleting `sources/` history
+- Building OAuth, Web UI, or cloud DB sync into this CLI MVP
 
 ## Quick checklist
 
@@ -314,6 +347,7 @@ Rules:
 [ ] Custom media use the generic guide (examples are not an allow-list)
 [ ] Merged context emitted for the requesting medium agent
 [ ] ~/.vibe-to-ui/ left untouched by any skill install/update path
+[ ] If sharing across devices/team: remote connect + sync; conflicts abort safely
 ```
 
 ## Token format (DTCG + DESIGN.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds zero-dependency Git remote sync for Design Context so `~/.vibe-to-ui` can be shared across devices and teammates via a private repo the user already controls.

### New commands

- `vibe-to-ui context remote connect <git-url>` — bind origin, fetch; restore remote profiles only when local is empty; never auto-upload or overwrite
- `vibe-to-ui context remote status` — remote URL, branch, local changes, ahead/behind, sync/conflict summary
- `vibe-to-ui context sync` — validate `tokens.json`, commit `profiles/` + `.gitignore`, `pull --rebase`, push `main`; on conflict abort rebase and report paths

### Safety

- Conflict → stop + `rebase --abort` (“No files were overwritten”)
- Invalid `tokens.json` blocks commit
- Secrets gitignored (`.env`, keys, credentials)

### Implementation

- New [`lib/git.js`](lib/git.js) / [`lib/remote.js`](lib/remote.js); wire-up in [`lib/context.js`](lib/context.js)
- Docs: DESIGN-CONTEXT, SKILL, README(s), AGENTS smoke

No OAuth, Web UI, LFS, or auto-merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ec5f24a-47d8-4a98-9668-3f2100d9dc6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ec5f24a-47d8-4a98-9668-3f2100d9dc6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

